### PR TITLE
LIN-27/feat: 컬러 팔레트, 폰트 사이즈 시스템 생성

### DIFF
--- a/.eslintrc.json
+++ b/.eslintrc.json
@@ -4,8 +4,7 @@
     "next/typescript", // Next.js의 공식 TypeScript 린팅 규칙
     "airbnb", // Airbnb의 JavaScript/React 규칙
     "prettier", // Prettier와 충돌하는 ESLint 규칙 끄기
-    "plugin:prettier/recommended", // Prettier 규칙을 ESLint 규칙으로 통합
-    "plugin:better-tailwindcss/recommended" // Tailwind v4를 지원하는 ESLint 플러그인
+    "plugin:prettier/recommended" // Prettier 규칙을 ESLint 규칙으로 통합
   ],
   "plugins": [
     "react",
@@ -13,7 +12,6 @@
     "import",
     "@typescript-eslint",
     "prettier",
-    "better-tailwindcss",
     "@tanstack/query"
   ],
   "parserOptions": {
@@ -103,8 +101,7 @@
         "ts": "never",
         "tsx": "never"
       }
-    ],
-    "better-tailwindcss/enforce-consistent-line-wrapping": "off"
+    ]
   },
   "overrides": [
     {

--- a/.prettierrc
+++ b/.prettierrc
@@ -1,4 +1,5 @@
 {
+  "plugins": ["prettier-plugin-tailwindcss"],
   "printWidth": 80,
   "tabWidth": 2,
   "useTabs": false,

--- a/package.json
+++ b/package.json
@@ -47,7 +47,6 @@
     "eslint-config-next": "14.2.30",
     "eslint-config-prettier": "^10.1.5",
     "eslint-import-resolver-typescript": "^4.4.4",
-    "eslint-plugin-better-tailwindcss": "^3.6.3",
     "eslint-plugin-import": "^2.32.0",
     "eslint-plugin-jsx-a11y": "^6.10.2",
     "eslint-plugin-prettier": "^5.5.1",
@@ -56,6 +55,7 @@
     "lint-staged": "^16.1.2",
     "postcss": "^8",
     "prettier": "^3.6.2",
+    "prettier-plugin-tailwindcss": "^0.6.14",
     "tailwindcss": "^4.1.11",
     "typescript": "^5"
   }

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -63,9 +63,6 @@ importers:
       eslint-import-resolver-typescript:
         specifier: ^4.4.4
         version: 4.4.4(eslint-plugin-import@2.32.0)(eslint@8.57.1)
-      eslint-plugin-better-tailwindcss:
-        specifier: ^3.6.3
-        version: 3.6.3(eslint@8.57.1)(tailwindcss@4.1.11)
       eslint-plugin-import:
         specifier: ^2.32.0
         version: 2.32.0(@typescript-eslint/parser@8.37.0(eslint@8.57.1)(typescript@5.8.3))(eslint-import-resolver-typescript@4.4.4)(eslint@8.57.1)
@@ -90,6 +87,9 @@ importers:
       prettier:
         specifier: ^3.6.2
         version: 3.6.2
+      prettier-plugin-tailwindcss:
+        specifier: ^0.6.14
+        version: 0.6.14(prettier@3.6.2)
       tailwindcss:
         specifier: ^4.1.11
         version: 4.1.11
@@ -125,10 +125,6 @@ packages:
   '@eslint-community/regexpp@4.12.1':
     resolution: {integrity: sha512-CCZCDJuduB9OUkFkY2IgppNZMi2lBQgD2qzwXkEia16cge2pijY/aXi96CJMquDMn3nJdlPV1A5KrJEXwfLNzQ==}
     engines: {node: ^12.0.0 || ^14.0.0 || >=16.0.0}
-
-  '@eslint/css-tree@3.6.1':
-    resolution: {integrity: sha512-5DIsBME23tUQD5zHD+T38lC2DG4jB8x8JRa+yDncLne2TIZA0VuCpcSazOX1EC+sM/q8w24qeevXfmfsIxAeqA==}
-    engines: {node: ^10 || ^12.20.0 || ^14.13.0 || >=15.0.0}
 
   '@eslint/eslintrc@2.1.4':
     resolution: {integrity: sha512-269Z39MS6wVJtsoUl10L60WdkhJVdPG24Q4eZTH3nnF6lpvSShEK3wQjDX9JRWAUPvPh7COouPpU9IrqaZFvtQ==}
@@ -946,13 +942,6 @@ packages:
       eslint-import-resolver-webpack:
         optional: true
 
-  eslint-plugin-better-tailwindcss@3.6.3:
-    resolution: {integrity: sha512-Xe1BMDIgINeQb1Xf7NLZHvi1S8V+4TXCnjheardPQsz6do38OAlqRSm0Uiq+biYzxNVofbJCkWNndW/3twjSkA==}
-    engines: {node: ^20.11.0 || >=21.2.0}
-    peerDependencies:
-      eslint: ^7.0.0 || ^8.0.0 || ^9.0.0
-      tailwindcss: ^3.3.0 || ^4.1.6
-
   eslint-plugin-import@2.32.0:
     resolution: {integrity: sha512-whOE1HFo/qJDyX4SnXzP4N6zOWn79WhnCUY/iDR0mPfQZO8wcYE4JClzI2oZrhBnnMUCBCHZhO6VQyoBU95mZA==}
     engines: {node: '>=4'}
@@ -1512,9 +1501,6 @@ packages:
     resolution: {integrity: sha512-/IXtbwEk5HTPyEwyKX6hGkYXxM9nbj64B+ilVJnC/R6B0pH5G4V3b0pVbL7DBj4tkhBAppbQUlf6F6Xl9LHu1g==}
     engines: {node: '>= 0.4'}
 
-  mdn-data@2.21.0:
-    resolution: {integrity: sha512-+ZKPQezM5vYJIkCxaC+4DTnRrVZR1CgsKLu5zsQERQx6Tea8Y+wMx5A24rq8A8NepCeatIQufVAekKNgiBMsGQ==}
-
   merge2@1.4.1:
     resolution: {integrity: sha512-8q7VEgMJW4J8tcfVPy8g09NcQwZdbwFEqhe/WZkoIzjn/3TGDwtOCYtXGxA3O8tPzpczCCDgv+P2P5y00ZJOOg==}
     engines: {node: '>= 8'}
@@ -1690,22 +1676,9 @@ packages:
     engines: {node: '>=0.10'}
     hasBin: true
 
-  pify@2.3.0:
-    resolution: {integrity: sha512-udgsAY+fTnvv7kI7aaxbqwWNb0AHiB0qBO89PZKPkoTmGOgdbrHDKD+0B2X4uTfJ/FT1R09r9gTsjUjNJotuog==}
-    engines: {node: '>=0.10.0'}
-
   possible-typed-array-names@1.1.0:
     resolution: {integrity: sha512-/+5VFTchJDoVj3bhoqi6UeymcD00DAwb1nJwamzPvHEszJ4FpF6SNNbUbOS8yI56qHzdV8eK0qEfOSiodkTdxg==}
     engines: {node: '>= 0.4'}
-
-  postcss-import@16.1.1:
-    resolution: {integrity: sha512-2xVS1NCZAfjtVdvXiyegxzJ447GyqCeEI5V7ApgQVOWnros1p5lGNovJNapwPpMombyFBfqDwt7AD3n2l0KOfQ==}
-    engines: {node: '>=18.0.0'}
-    peerDependencies:
-      postcss: ^8.0.0
-
-  postcss-value-parser@4.2.0:
-    resolution: {integrity: sha512-1NNCs6uurfkVbeXG4S8JFT9t19m45ICnif8zWLd5oPSZ50QnwMfK+H3jv408d4jw/7Bttv5axS5IiHoLaVNHeQ==}
 
   postcss@8.4.31:
     resolution: {integrity: sha512-PS08Iboia9mts/2ygV3eLpY5ghnUcfLV/EXTOW1E2qYxJKGGBUtNjN76FYHnMs36RmARn41bC0AZmn+rR0OVpQ==}
@@ -1722,6 +1695,67 @@ packages:
   prettier-linter-helpers@1.0.0:
     resolution: {integrity: sha512-GbK2cP9nraSSUF9N2XwUwqfzlAFlMNYYl+ShE/V+H8a9uNl/oUqB1w2EL54Jh0OlyRSd8RfWYJ3coVS4TROP2w==}
     engines: {node: '>=6.0.0'}
+
+  prettier-plugin-tailwindcss@0.6.14:
+    resolution: {integrity: sha512-pi2e/+ZygeIqntN+vC573BcW5Cve8zUB0SSAGxqpB4f96boZF4M3phPVoOFCeypwkpRYdi7+jQ5YJJUwrkGUAg==}
+    engines: {node: '>=14.21.3'}
+    peerDependencies:
+      '@ianvs/prettier-plugin-sort-imports': '*'
+      '@prettier/plugin-hermes': '*'
+      '@prettier/plugin-oxc': '*'
+      '@prettier/plugin-pug': '*'
+      '@shopify/prettier-plugin-liquid': '*'
+      '@trivago/prettier-plugin-sort-imports': '*'
+      '@zackad/prettier-plugin-twig': '*'
+      prettier: ^3.0
+      prettier-plugin-astro: '*'
+      prettier-plugin-css-order: '*'
+      prettier-plugin-import-sort: '*'
+      prettier-plugin-jsdoc: '*'
+      prettier-plugin-marko: '*'
+      prettier-plugin-multiline-arrays: '*'
+      prettier-plugin-organize-attributes: '*'
+      prettier-plugin-organize-imports: '*'
+      prettier-plugin-sort-imports: '*'
+      prettier-plugin-style-order: '*'
+      prettier-plugin-svelte: '*'
+    peerDependenciesMeta:
+      '@ianvs/prettier-plugin-sort-imports':
+        optional: true
+      '@prettier/plugin-hermes':
+        optional: true
+      '@prettier/plugin-oxc':
+        optional: true
+      '@prettier/plugin-pug':
+        optional: true
+      '@shopify/prettier-plugin-liquid':
+        optional: true
+      '@trivago/prettier-plugin-sort-imports':
+        optional: true
+      '@zackad/prettier-plugin-twig':
+        optional: true
+      prettier-plugin-astro:
+        optional: true
+      prettier-plugin-css-order:
+        optional: true
+      prettier-plugin-import-sort:
+        optional: true
+      prettier-plugin-jsdoc:
+        optional: true
+      prettier-plugin-marko:
+        optional: true
+      prettier-plugin-multiline-arrays:
+        optional: true
+      prettier-plugin-organize-attributes:
+        optional: true
+      prettier-plugin-organize-imports:
+        optional: true
+      prettier-plugin-sort-imports:
+        optional: true
+      prettier-plugin-style-order:
+        optional: true
+      prettier-plugin-svelte:
+        optional: true
 
   prettier@3.6.2:
     resolution: {integrity: sha512-I7AIg5boAr5R0FFtJ6rCfD+LFsWHp81dolrFD8S79U9tb8Az2nGrJncnMSnys+bpQJfRUzqs9hnA81OAA3hCuQ==}
@@ -1752,9 +1786,6 @@ packages:
   react@18.3.1:
     resolution: {integrity: sha512-wS+hAgJShR0KhEvPJArfuPVN1+Hz1t0Y6n5jLrGQbkb4urgPE/0Rve+1kMB1v/oWgHgm4WIcV+i7F2pTVj+2iQ==}
     engines: {node: '>=0.10.0'}
-
-  read-cache@1.0.0:
-    resolution: {integrity: sha512-Owdv/Ft7IjOgm/i0xvNDZ1LrRANRfew4b2prF3OWMQLxLfu3bS8FVhCsrSCMK4lR56Y9ya+AThoTpDCTxCmpRA==}
 
   reflect.getprototypeof@1.0.10:
     resolution: {integrity: sha512-00o4I+DVrefhv+nX0ulyi3biSHCPDe+yLv5o/p6d/UVlirijB8E16FtfwSAi4g3tcqrQ4lRAqQSoFEZJehYEcw==}
@@ -1970,10 +2001,6 @@ packages:
     resolution: {integrity: sha512-+XZ+r1XGIJGeQk3VvXhT6xx/VpbHsRzsTkGgF6E5RX9TTXD0118l87puaEBZ566FhqblC6U0d4XnubznJDm30A==}
     engines: {node: ^14.18.0 || >=16.0.0}
 
-  tailwind-csstree@0.1.1:
-    resolution: {integrity: sha512-Tv5IXRHtlb7LanNXjmGg0vu84Iu+/sKDqTLJBO0kP/rggfjJDKnS/HV+e0qn8yIrRByhGg+908rSOxT/7o1diw==}
-    engines: {node: '>=18.18'}
-
   tailwind-merge@3.3.1:
     resolution: {integrity: sha512-gBXpgUm/3rp1lMZZrM/w7D8GKqshif0zAymAhbCyIt8KMe+0v9DQ7cdYLR4FHH/cKpdTXb+A/tKKU3eolfsI+g==}
 
@@ -2155,11 +2182,6 @@ snapshots:
       eslint-visitor-keys: 3.4.3
 
   '@eslint-community/regexpp@4.12.1': {}
-
-  '@eslint/css-tree@3.6.1':
-    dependencies:
-      mdn-data: 2.21.0
-      source-map-js: 1.2.1
 
   '@eslint/eslintrc@2.1.4':
     dependencies:
@@ -3044,18 +3066,6 @@ snapshots:
     transitivePeerDependencies:
       - supports-color
 
-  eslint-plugin-better-tailwindcss@3.6.3(eslint@8.57.1)(tailwindcss@4.1.11):
-    dependencies:
-      '@eslint/css-tree': 3.6.1
-      enhanced-resolve: 5.18.2
-      eslint: 8.57.1
-      jiti: 2.4.2
-      postcss: 8.5.6
-      postcss-import: 16.1.1(postcss@8.5.6)
-      synckit: 0.11.8
-      tailwind-csstree: 0.1.1
-      tailwindcss: 4.1.11
-
   eslint-plugin-import@2.32.0(@typescript-eslint/parser@8.37.0(eslint@8.57.1)(typescript@5.8.3))(eslint-import-resolver-typescript@3.10.1)(eslint@8.57.1):
     dependencies:
       '@rtsao/scc': 1.1.0
@@ -3718,8 +3728,6 @@ snapshots:
 
   math-intrinsics@1.1.0: {}
 
-  mdn-data@2.21.0: {}
-
   merge2@1.4.1: {}
 
   micromatch@4.0.8:
@@ -3886,18 +3894,7 @@ snapshots:
 
   pidtree@0.6.0: {}
 
-  pify@2.3.0: {}
-
   possible-typed-array-names@1.1.0: {}
-
-  postcss-import@16.1.1(postcss@8.5.6):
-    dependencies:
-      postcss: 8.5.6
-      postcss-value-parser: 4.2.0
-      read-cache: 1.0.0
-      resolve: 1.22.10
-
-  postcss-value-parser@4.2.0: {}
 
   postcss@8.4.31:
     dependencies:
@@ -3916,6 +3913,10 @@ snapshots:
   prettier-linter-helpers@1.0.0:
     dependencies:
       fast-diff: 1.3.0
+
+  prettier-plugin-tailwindcss@0.6.14(prettier@3.6.2):
+    dependencies:
+      prettier: 3.6.2
 
   prettier@3.6.2: {}
 
@@ -3942,10 +3943,6 @@ snapshots:
   react@18.3.1:
     dependencies:
       loose-envify: 1.4.0
-
-  read-cache@1.0.0:
-    dependencies:
-      pify: 2.3.0
 
   reflect.getprototypeof@1.0.10:
     dependencies:
@@ -4204,8 +4201,6 @@ snapshots:
   synckit@0.11.8:
     dependencies:
       '@pkgr/core': 0.2.7
-
-  tailwind-csstree@0.1.1: {}
 
   tailwind-merge@3.3.1: {}
 

--- a/src/app/globals.css
+++ b/src/app/globals.css
@@ -3,19 +3,166 @@
 @theme {
   --color-background: var(--background);
   --color-foreground: var(--foreground);
+
+  /* --- chromatic color palette --- */
+  --color-taskify-violet-primary: var(--violet-5534DA);
+  --color-taskify-violet-light: var(--violet-F1EFFD);
+  --color-taskify-red: var(--red-D6173A);
+  --color-taskify-green: var(--green-7AC555);
+  --color-taskify-purple: var(--purple-760DDE);
+  --color-taskify-orange: var(--orange-FFA500);
+  --color-taskify-blue: var(--blue-76A6EA);
+  --color-taskify-pink: var(--pink-E876EA);
+
+  /* --- neutral color palette --- */
+  --color-taskify-neutral-900: var(--black-000000);
+  --color-taskify-neutral-800: var(--black-171717);
+  --color-taskify-neutral-700: var(--black-333236);
+  --color-taskify-neutral-600: var(--black-4B4B4B);
+  --color-taskify-neutral-500: var(--gray-787486);
+  --color-taskify-neutral-400: var(--gray-9FA6B2);
+  --color-taskify-neutral-300: var(--gray-D9D9D9);
+  --color-taskify-neutral-200: var(--gray-EEEEEE);
+  --color-taskify-neutral-100: var(--gray-FAFAFA);
+  --color-taskify-neutral-0: var(--white-FFFFFF);
+}
+
+/*
+  여기에 프로젝트에서 자주 사용하는 사용자 정의 유틸리티 클래스를 추가할 수 있습니다.
+  예:
+  @utility flex-center {
+    @apply flex items-center justify-center;
+  }
+*/
+
+/* --- xs (12px/18px) xs-semibold (12px/20px) --- */
+@utility text-taskify-xs-normal {
+  @apply text-xs leading-4.5 font-normal; /* 18px = leading-4.5 */
+}
+
+@utility text-taskify-xs-medium {
+  @apply text-xs leading-4.5 font-medium;
+}
+
+@utility text-taskify-xs-semibold {
+  @apply text-xs leading-5 font-semibold; /* 20px = leading-5 */
+}
+
+/* --- sm (13px/22px) --- */
+@utility text-taskify-sm-medium {
+  @apply text-[13px] leading-[22px] font-medium;
+}
+
+@utility text-taskify-sm-semibold {
+  @apply text-[13px] leading-[22px] font-semibold;
+}
+
+/* --- md (14px/24px) --- */
+@utility text-taskify-md-regular {
+  @apply text-sm leading-6 font-normal; /* 24px = leading-6 */
+}
+
+@utility text-taskify-md-medium {
+  @apply text-sm leading-6 font-medium;
+}
+
+@utility text-taskify-md-semibold {
+  @apply text-sm leading-6 font-semibold;
+}
+
+@utility text-taskify-md-bold {
+  @apply text-sm leading-6 font-bold;
+}
+
+/* --- lg (16px/26px) --- */
+@utility text-taskify-lg-regular {
+  @apply text-base leading-[26px] font-normal; /* 16px = text-base */
+}
+
+@utility text-taskify-lg-medium {
+  @apply text-base leading-[26px] font-medium;
+}
+
+@utility text-taskify-lg-semibold {
+  @apply text-base leading-[26px] font-semibold;
+}
+
+@utility text-taskify-lg-bold {
+  @apply text-base leading-[26px] font-bold;
+}
+
+/* --- 2lg (18px/26px) --- */
+@utility text-taskify-2lg-regular {
+  @apply text-[18px] leading-[26px] font-normal;
+}
+
+@utility text-taskify-2lg-medium {
+  @apply text-[18px] leading-[26px] font-medium;
+}
+
+@utility text-taskify-2lg-semibold {
+  @apply text-[18px] leading-[26px] font-semibold;
+}
+
+@utility text-taskify-2lg-bold {
+  @apply text-[18px] leading-[26px] font-bold;
+}
+
+/* --- xl (20px/32px) --- */
+@utility text-taskify-xl-regular {
+  @apply text-xl leading-8 font-normal; /* 20px = text-xl, 32px = leading-8 */
+}
+
+@utility text-taskify-xl-medium {
+  @apply text-xl leading-8 font-medium;
+}
+
+@utility text-taskify-xl-semibold {
+  @apply text-xl leading-8 font-semibold;
+}
+
+@utility text-taskify-xl-bold {
+  @apply text-xl leading-8 font-bold;
+}
+
+/* --- 2xl (24px/32px) --- */
+@utility text-taskify-2xl-regular {
+  @apply text-2xl leading-8 font-normal; /* 24px = text-2xl, 32px = leading-8 */
+}
+
+@utility text-taskify-2xl-medium {
+  @apply text-2xl leading-8 font-medium;
+}
+
+@utility text-taskify-2xl-semibold {
+  @apply text-2xl leading-8 font-semibold;
+}
+
+@utility text-taskify-2xl-bold {
+  @apply text-2xl leading-8 font-bold;
+}
+
+/* --- 3xl (32px/42px) --- */
+@utility text-taskify-3xl-semibold {
+  @apply text-3xl leading-[42px] font-semibold; /* 32px = text-3xl */
+}
+
+@utility text-taskify-3xl-bold {
+  @apply text-3xl leading-[42px] font-bold;
 }
 
 @utility text-balance {
   /* 텍스트 줄바꿈 균등 분배 (Next.js 기본 템플릿 포함) */
   text-wrap: balance;
+}
 
-  /*
-    여기에 프로젝트에서 자주 사용하는 사용자 정의 유틸리티 클래스를 추가할 수 있습니다.
-    예:
-    .flex-center {
-      @apply flex items-center justify-center;
-    }
-  */
+/* --- 컴포넌트 기본 스타일 (필요시 추가) --- */
+@layer components {
+  /*   
+  .btn-primary {
+    @apply bg-primary text-background px-4 py-2 rounded-md hover:opacity-90;
+  }
+   */
 }
 
 @layer utilities {
@@ -25,6 +172,26 @@
   :root {
     --background: #ffffff;
     --foreground: #171717;
+
+    --violet-5534DA: #5534da;
+    --violet-F1EFFD: #f1effd;
+    --red-D6173A: #d6173a;
+    --green-7AC555: #7ac555;
+    --purple-760DDE: #760dde;
+    --orange-FFA500: #ffa500;
+    --blue-76A6EA: #76a6ea;
+    --pink-E876EA: #e876ea;
+
+    --black-000000: #000000;
+    --black-171717: #171717;
+    --black-333236: #333236;
+    --black-4B4B4B: #4b4b4b;
+    --gray-787486: #787486;
+    --gray-9FA6B2: #9fa6b2;
+    --gray-D9D9D9: #d9d9d9;
+    --gray-EEEEEE: #eeeeee;
+    --gray-FAFAFA: #fafafa;
+    --white-FFFFFF: #ffffff;
   }
 
   @media (prefers-color-scheme: dark) {
@@ -66,15 +233,4 @@
     max-width: 100%;
     height: auto;
   }
-
-  /* --- Tailwind @layer 유틸리티 (필요시 추가) --- */
-}
-
-/* --- 컴포넌트 기본 스타일 (필요시 추가) --- */
-@layer components {
-  /*   
-  .btn-primary {
-    @apply bg-primary text-background px-4 py-2 rounded-md hover:opacity-90;
-  }
-   */
 }


### PR DESCRIPTION
### 🚨 PR 제목 컨벤션 (필수)

- `feat: 새로운 기능 추가`
- `fix: 버그 수정`
- `docs: 문서 변경`
- `chore: 기타 작업`
- `허용된 타입 목록: feat|fix|docs|style|refactor|perf|test|build|ci|chore|revert`
- Linear Issue Key 를 포함해주세요. 예: `LIN-123/feat: 새로운 기능 추가`

## 🪓 관련 Linear Issue

Linear 이슈 링크: [LIN-27: 컬러 팔레트, 폰트 사이즈 시스템 생성](https://linear.app/fe16-intermediate-project/issue/LIN-27/컬러-팔레트-폰트-사이즈-시스템-생성)

## 💡 변경 사항 요약

`global.css` 파일 내부에 컬러 및 폰트 팔레트 추가

### 📌 세부 변경 내용

**공통**

`taskify` 접두어 사용하여 커스터마이징 CSS에 접근 가능

**Color 팔레트**: 기존 `color`가 들어가는 자리에 대체해서 사용 가능
 - ex) `bg-taskify-green`, `text-taskify-violet-light`

**Text 팔레트**: `text` 접두어 뒤에 사용 가능
- ex) `text-taskify-2xl-regular`

자세한 컬러 폰트 값은 Figma 디자인 시안을 참조하거나 `global.css` 내부 코드를 참조

### 📸 스크린샷 (선택 사항)

### ✍️ 추가 코멘트 (선택 사항)

- `@utility` 지시어를 사용하여 utiliry class를 커스터마이징 했으나, 비슷한 작업의 연속이라 중복이 심해보입니다.
- 혹시 더 나은 방법을 알고 계시다면 피드백 환영합니다. (CSS-in-JS 방식의 프로젝트에서는 mixin 함수를 활용했습니다.)
