### PR TITLE
LIN-24/feat: API(Invitations, Columns-Users 내 이미지 업로드) 추가

### DIFF
--- a/src/hooks/useGetInvitations.ts
+++ b/src/hooks/useGetInvitations.ts
@@ -1,0 +1,12 @@
+import { useQuery } from '@tanstack/react-query';
+
+import { getInvitations } from '@/lib/api/invitations';
+
+// 초대 목록을 불러오는 훅
+
+export const useGetInvitations = () => {
+  return useQuery({
+    queryKey: ['invitations'],
+    queryFn: () => getInvitations({}),
+  });
+};

--- a/src/hooks/usePutInvitation.ts
+++ b/src/hooks/usePutInvitation.ts
@@ -1,0 +1,21 @@
+import { useMutation, useQueryClient } from '@tanstack/react-query';
+
+import { putInvitation } from '@/lib/api/invitations';
+
+// 초대 수락-거절 훅
+
+export const usePutInvitation = () => {
+  const queryClient = useQueryClient();
+
+  return useMutation({
+    mutationFn: (params: { invitationId: number; inviteAccepted: boolean }) =>
+      putInvitation(
+        { invitationId: params.invitationId },
+        { inviteAccepted: params.inviteAccepted },
+      ),
+    // 성공 시 초대 목록 다시 불러오기
+    onSuccess: () => {
+      queryClient.invalidateQueries({ queryKey: ['invitations'] });
+    },
+  });
+};

--- a/src/lib/api/columns.ts
+++ b/src/lib/api/columns.ts
@@ -1,0 +1,19 @@
+import axiosInstance from '../axiosInstance';
+
+export const uploadCardImage = async ({
+  columnId,
+  file,
+}: {
+  columnId: number;
+  file: File;
+}): Promise<string> => {
+  const formData = new FormData();
+  formData.append('image', file);
+
+  const response = await axiosInstance.post(
+    `/columns/${columnId}/card-image`,
+    formData,
+  );
+
+  return response.data.imageUrl;
+};

--- a/src/lib/api/invitations.ts
+++ b/src/lib/api/invitations.ts
@@ -1,0 +1,72 @@
+import axiosInstance from '../axiosInstance';
+
+// 0. 공통 타입 정의
+
+export interface UserInfo {
+  id: number;
+  nickname: string;
+  email: string;
+}
+
+export interface DashboardInfo {
+  id: number;
+  title: string;
+}
+
+export interface Invitation {
+  id: number;
+  inviter: UserInfo;
+  invitee: UserInfo;
+  teamId: string;
+  dashboard: DashboardInfo;
+  inviteAccepted: boolean;
+  createdAt: string;
+  updatedAt: string;
+}
+
+// 1. GET - 내가 받은 초대 목록 조회
+
+export interface GetInvitationsResponse {
+  cursorId: number;
+  invitations: Invitation[];
+}
+
+export interface GetInvitationsParams {
+  size?: number;
+  cursorId?: number;
+  title?: string;
+}
+
+export const getInvitations = async ({
+  size = 10,
+  cursorId,
+  title,
+}: GetInvitationsParams): Promise<GetInvitationsResponse> => {
+  const response = await axiosInstance.get<GetInvitationsResponse>(
+    `/invitations`,
+    { params: { size, cursorId, title } },
+  );
+
+  return response.data;
+};
+
+// 2. PUT - 초대 응답
+
+export interface PutInvitationsParams {
+  invitationId: number;
+}
+
+export interface PutInvitationsRequest {
+  inviteAccepted: boolean;
+}
+
+export const putInvitation = async (
+  { invitationId }: PutInvitationsParams,
+  body: PutInvitationsRequest,
+): Promise<Invitation> => {
+  const response = await axiosInstance.put<Invitation>(
+    `/invitations/${invitationId}`,
+    body,
+  );
+  return response.data;
+};

--- a/src/lib/api/users.ts
+++ b/src/lib/api/users.ts
@@ -1,0 +1,14 @@
+import axiosInstance from '../axiosInstance';
+
+export const uploadProfileImage = async ({
+  file,
+}: {
+  file: File;
+}): Promise<string> => {
+  const formData = new FormData();
+  formData.append('image', file);
+
+  const response = await axiosInstance.post(`/users/me/image`, formData);
+
+  return response.data.profileImageUrl;
+};


### PR DESCRIPTION
### 🚨 PR 제목 컨벤션 (필수)

- `feat: 새로운 기능 추가`
- `fix: 버그 수정`
- `docs: 문서 변경`
- `chore: 기타 작업`
- `허용된 타입 목록: feat|fix|docs|style|refactor|perf|test|build|ci|chore|revert`
- Linear Issue Key 를 포함해주세요. 예: `LIN-123/feat: 새로운 기능 추가`

## 🪓 관련 Linear Issue

Linear 이슈 링크: https://linear.app/fe16-intermediate-project/issue/LIN-24/api-invitations-columns-users-내-이미지-업로드

## 💡 변경 사항 요약

초대 목록(Invitations), 이미지 업로드 관련 API 및 훅 추가

### 📌 세부 변경 내용

- 초대 목록(Invitations) API
-> 내가 초대된 목록 조회 (GET /invitations)
-> 초대 응답 (PUT /invitations/{invitationId})

- 컬럼(Columns) API
-> 카드 이미지 업로드 (POST /columns/{columnId}/card-image)

- 유저(Users) API
-> 프로필 이미지 업로드(POST /users/me/image)

- 초대 목록 관련 훅
-> useGetInvitations.ts : 초대 목록 불러오는 훅
-> usePutInvitation.ts: 초대 수락-거절 훅

### 🧪 테스트 방법 및 결과 (선택 사항)

### 📸 스크린샷 (선택 사항)

### ✍️ 추가 코멘트 (선택 사항)
- 타입 파일 분리가 필요한지 의논 필요
- axiosInstance 내 header 논의 필요(이미지 api의 경우 Request body가 multipart/form-data 형식)
- teamId는 axiosInstance 내 BaseUrl에 포함되어있다는 가정 하에 제작
