### PR TITLE
LIN-31/chore: TailwindCSS 관련 ESLint 플러그인 제거

### DIFF
--- a/.eslintrc.json
+++ b/.eslintrc.json
@@ -29,11 +29,6 @@
       "typescript": {
         "alwaysTryTypes": true
       }
-    },
-    "better-tailwindcss": {
-      // 'postcss.config.mjs' 파일의 경로를 정확하게 지정해주세요.
-      // 프로젝트 루트에 있다면 이렇게 설정합니다.
-      "tailwindCssConfig": "./postcss.config.mjs"
     }
   },
   "rules": {
@@ -106,6 +101,7 @@
         "ts": "never",
         "tsx": "never"
       }
+    ]
   },
   "overrides": [
     {

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -2304,9 +2304,6 @@ packages:
   mdn-data@2.0.30:
     resolution: {integrity: sha512-GaqWWShW4kv/G9IEucWScBx9G1/vsFZZJUO+tD26M8J8z3Kw5RDQjaoZe03YAClgeS/SWPOcb4nkFBTEi5DUEA==}
 
-  mdn-data@2.21.0:
-    resolution: {integrity: sha512-+ZKPQezM5vYJIkCxaC+4DTnRrVZR1CgsKLu5zsQERQx6Tea8Y+wMx5A24rq8A8NepCeatIQufVAekKNgiBMsGQ==}
-
   merge2@1.4.1:
     resolution: {integrity: sha512-8q7VEgMJW4J8tcfVPy8g09NcQwZdbwFEqhe/WZkoIzjn/3TGDwtOCYtXGxA3O8tPzpczCCDgv+P2P5y00ZJOOg==}
     engines: {node: '>= 8'}
@@ -2506,6 +2503,9 @@ packages:
   possible-typed-array-names@1.1.0:
     resolution: {integrity: sha512-/+5VFTchJDoVj3bhoqi6UeymcD00DAwb1nJwamzPvHEszJ4FpF6SNNbUbOS8yI56qHzdV8eK0qEfOSiodkTdxg==}
     engines: {node: '>= 0.4'}
+
+  postcss-value-parser@4.2.0:
+    resolution: {integrity: sha512-1NNCs6uurfkVbeXG4S8JFT9t19m45ICnif8zWLd5oPSZ50QnwMfK+H3jv408d4jw/7Bttv5axS5IiHoLaVNHeQ==}
 
   postcss@8.4.31:
     resolution: {integrity: sha512-PS08Iboia9mts/2ygV3eLpY5ghnUcfLV/EXTOW1E2qYxJKGGBUtNjN76FYHnMs36RmARn41bC0AZmn+rR0OVpQ==}
@@ -5593,8 +5593,6 @@ snapshots:
 
   mdn-data@2.0.30: {}
 
-  mdn-data@2.21.0: {}
-
   merge2@1.4.1: {}
 
   micromatch@4.0.8:
@@ -5784,6 +5782,8 @@ snapshots:
   pidtree@0.6.0: {}
 
   possible-typed-array-names@1.1.0: {}
+
+  postcss-value-parser@4.2.0: {}
 
   postcss@8.4.31:
     dependencies:


### PR DESCRIPTION
### 🚨 PR 제목 컨벤션 (필수)

- `feat: 새로운 기능 추가`
- `fix: 버그 수정`
- `docs: 문서 변경`
- `chore: 기타 작업`
- `허용된 타입 목록: feat|fix|docs|style|refactor|perf|test|build|ci|chore|revert`
- Linear Issue Key 를 포함해주세요. 예: `LIN-123/feat: 새로운 기능 추가`

## 🪓 관련 Linear Issue

Linear 이슈 링크: [LIN-33: Tailwind + ESLint 문제 해결](https://linear.app/fe16-intermediate-project/issue/LIN-33/tailwind-eslint-문제-해결)

## 💡 변경 사항 요약

TailwindCSS 관련 ESLint 플러그인 제거

### 📌 세부 변경 내용

- TailwindCSS 관련 ESLint 플러그인 제거
- prettier-plugin-tailwindcss만 사용
