### PR TITLE
LIN-49/feat: myboard 내 대시보드 컴포넌트 추가

### DIFF
--- a/src/app/mydashboard/components/dashboard/DashboardHeader.tsx
+++ b/src/app/mydashboard/components/dashboard/DashboardHeader.tsx
@@ -1,0 +1,34 @@
+import Image from 'next/image';
+
+import crownIcon from '@/../public/images/icon/crown.svg';
+
+const DashboardHeader = ({
+  title,
+  color,
+  createdByMe,
+}: {
+  title: string;
+  color: string;
+  createdByMe: boolean;
+}) => (
+  // h2 외곽을 hover하더라도 반영될 수 있게 group 처리
+  <div className="group flex items-center gap-2 md:self-center lg:mt-4 lg:self-auto">
+    {/* 컬러 닷 */}
+    <span
+      className="size-3 shrink-0 rounded-full"
+      style={{ backgroundColor: color }}
+    />
+
+    {/* 타이틀. md에서 hover하면 제목 길이가 짧게 축약되며 아바타 출력 */}
+    <h2 className="text-taskify-lg-medium text-taskify-neutral-600 max-w-[200px] truncate overflow-hidden md:max-w-[180px] md:group-hover:max-w-[100px] lg:max-w-[100px]">
+      {title}
+    </h2>
+
+    {/* 자신이 만든 대시보드일 경우 왕관 아이콘 출력 */}
+    <div className="shrink-0">
+      {createdByMe && <Image src={crownIcon} alt="owner" />}
+    </div>
+  </div>
+);
+
+export default DashboardHeader;

--- a/src/app/mydashboard/components/dashboard/DashboardList.tsx
+++ b/src/app/mydashboard/components/dashboard/DashboardList.tsx
@@ -1,0 +1,74 @@
+'use client';
+
+import { useQuery } from '@tanstack/react-query';
+import { useEffect, useState } from 'react';
+
+import PaginationButton from '@/components/ui/PaginationButton';
+import { Skeleton } from '@/components/ui/skeleton';
+import { getDashboards } from '@/lib/api/dashboardService';
+
+import DashboardListItem from './DashboardListItem';
+import NewDashboardCard from './NewDashboardCard';
+
+const DashboardList = () => {
+  const [page, setPage] = useState(1);
+  const [itemsPerPage, setItemsPerPage] = useState(4);
+
+  const { data, isPending, isError, error } = useQuery({
+    queryKey: ['dashboards', page, itemsPerPage],
+    queryFn: () =>
+      getDashboards({
+        navigationMethod: 'pagination',
+        page,
+        size: itemsPerPage,
+      }),
+    staleTime: 1000 * 60 * 5,
+  });
+
+  // 펜딩과 에러 처리 수정 필요(임시)
+  if (isPending) <Skeleton />;
+  if (isError) <p>에러가 발생했습니다. {error.message}</p>;
+
+  const dashboards = data?.dashboards ?? [];
+
+  // 반응형 크기에 따라 페이지당 출력하는 대시보드 목록 변경하는 로직
+  useEffect(() => {
+    const updateItemsPerPage = () => {
+      const width = window.innerWidth;
+      if (width < 768) {
+        setItemsPerPage(5); // 모바일
+      } else if (width < 1024) {
+        setItemsPerPage(5); // 태블릿
+      } else {
+        setItemsPerPage(4); // 데스크탑
+      }
+    };
+
+    updateItemsPerPage(); // 초기 설정
+    window.addEventListener('resize', updateItemsPerPage);
+    return () => window.removeEventListener('resize', updateItemsPerPage);
+  }, []);
+
+  return (
+    <>
+      <div className="mx-auto w-full max-w-[1000px] px-3 lg:mt-1">
+        <div className="mt-4.5 grid grid-cols-1 gap-2.5 md:grid-cols-2 lg:grid-cols-5">
+          <NewDashboardCard />
+          {dashboards.map((dashboard) => (
+            <DashboardListItem key={dashboard.id} dashboard={dashboard} />
+          ))}
+        </div>
+      </div>
+      <div className="absolute top-[495px] left-[170px] flex justify-center md:top-[388px] md:left-[585px] lg:top-[350px] lg:left-[1145px]">
+        <PaginationButton
+          page={page}
+          size={itemsPerPage}
+          totalCount={data?.totalCount ?? 0}
+          onPageChange={setPage}
+        />
+      </div>
+    </>
+  );
+};
+
+export default DashboardList;

--- a/src/app/mydashboard/components/dashboard/DashboardListItem.tsx
+++ b/src/app/mydashboard/components/dashboard/DashboardListItem.tsx
@@ -1,0 +1,49 @@
+'use client';
+
+import { useRouter } from 'next/navigation';
+
+import { useMemberStore } from '@/stores/useMemberStore';
+import { Dashboard } from '@/types/Dashboard';
+
+import DashboardHeader from './DashboardHeader';
+import MemberAvatars from './MemberAvatars';
+import MemberCountText from './MemberCountText';
+
+interface DashboardListItemProps {
+  dashboard: Dashboard;
+}
+
+const DashboardListItem = ({ dashboard }: DashboardListItemProps) => {
+  const router = useRouter();
+  const members = useMemberStore((state) => state.members);
+
+  // 카드 개별 구성
+  // PC : 헤더 + 멤버아바타 + 멤버카운트, 태블릿 : 헤더 + 호버 시 멤버 아바타, 모바일 : 헤더
+  return (
+    <div
+      role="button"
+      tabIndex={0}
+      onClick={() => router.push(`/dashboard/${dashboard.id}`)}
+      onKeyDown={(e) => {
+        if (e.key === 'Enter' || e.key === ' ') {
+          router.push(`/dashboard/${dashboard.id}`);
+        }
+      }}
+      className="group relative flex min-h-[58px] w-[290px] cursor-pointer flex-col items-start justify-between gap-2 rounded-lg border p-4 transition hover:shadow-sm md:min-h-[68px] md:w-[275px] md:flex-row lg:min-h-[175px] lg:w-[175px] lg:flex-col"
+    >
+      <DashboardHeader
+        title={dashboard.title}
+        color={dashboard.color}
+        createdByMe={dashboard.createdByMe}
+      />
+      <div className="hidden transition-all duration-200 group-hover:opacity-100 md:absolute md:top-5 md:left-44 md:group-hover:block lg:relative lg:top-auto lg:left-auto lg:-mt-6 lg:block">
+        <MemberAvatars />
+      </div>
+      <div className="hidden lg:mb-2 lg:block">
+        <MemberCountText count={members.length} />
+      </div>
+    </div>
+  );
+};
+
+export default DashboardListItem;

--- a/src/app/mydashboard/components/dashboard/DashboardSection.tsx
+++ b/src/app/mydashboard/components/dashboard/DashboardSection.tsx
@@ -1,0 +1,64 @@
+'use client';
+
+import { useQuery } from '@tanstack/react-query';
+
+import CreateDashboardDialog from '@/components/common/dialog/CreateDashboardDialog';
+import { Skeleton } from '@/components/ui/skeleton';
+import { getDashboards } from '@/lib/api/dashboardService';
+import { useDialogStore } from '@/stores/useDialogStore';
+
+import DashboardList from './DashboardList';
+import NewDashboard from './NewDashboard';
+
+// 대시보드 리스트 총괄
+const DashboardSection = () => {
+  const { data, isPending, isError, error } = useQuery({
+    queryKey: ['dashboards'],
+    queryFn: () =>
+      getDashboards({
+        navigationMethod: 'pagination',
+        page: 1,
+        size: 100,
+      }),
+    staleTime: 1000 * 60 * 5,
+  });
+
+  const { openDialog } = useDialogStore();
+
+  if (isPending) return <Skeleton />;
+  if (isError) return <div>에러 발생: {error.message}</div>;
+
+  const hasDashboards = (data?.dashboards?.length ?? 0) > 0;
+
+  // 기존 대시보드 목록이 없을 시 새로운 대시보드 만들 수 있는 버튼 출력
+  return (
+    <div className="bg-taskify-neutral-0 mb-14 flex h-[550px] w-[340px] flex-col rounded-2xl p-6 px-[15px] md:h-[360px] md:w-[620px] lg:h-[330px] lg:w-[1022px]">
+      <h1 className="text-taskify-2xl-bold text-taskify-neutral-700 md:ml-4 lg:ml-4">
+        대시보드
+      </h1>
+      {hasDashboards ? (
+        <DashboardList />
+      ) : (
+        <div
+          role="button"
+          tabIndex={0}
+          className="flex flex-1 cursor-pointer items-center justify-center"
+          onClick={() =>
+            openDialog({
+              dialogComponent: <CreateDashboardDialog />,
+            })
+          }
+          onKeyDown={(e) => {
+            if (e.key === 'Enter' || e.key === ' ') {
+              openDialog({ dialogComponent: <CreateDashboardDialog /> });
+            }
+          }}
+        >
+          <NewDashboard />
+        </div>
+      )}
+    </div>
+  );
+};
+
+export default DashboardSection;

--- a/src/app/mydashboard/components/dashboard/MemberAvatars.tsx
+++ b/src/app/mydashboard/components/dashboard/MemberAvatars.tsx
@@ -1,0 +1,33 @@
+'use client';
+
+import { AvatarProfile } from '@/components/common/Profile';
+import { useMemberStore } from '@/stores/useMemberStore';
+
+const MemberAvatars = () => {
+  const members = useMemberStore((state) => state.getMembers());
+
+  // 아바타는 3명까지만 노출되며 그 이후는 +rest로 처리
+  const visible = members.slice(0, 3);
+  const rest = members.length - visible.length;
+
+  return (
+    <div className="flex">
+      {visible.map((member, idx) => (
+        <div key={member.id} className={idx !== 0 ? '-ml-2' : ''}>
+          <AvatarProfile
+            userName={member.nickname}
+            profileImg={member.profileImageUrl}
+            size="sm"
+          />
+        </div>
+      ))}
+      {rest > 0 && (
+        <div className="bg-muted text-muted-foreground z-10 -ml-2 flex size-[26px] items-center justify-center rounded-full border border-white text-xs font-medium">
+          +{rest}
+        </div>
+      )}
+    </div>
+  );
+};
+
+export default MemberAvatars;

--- a/src/app/mydashboard/components/dashboard/MemberCountText.tsx
+++ b/src/app/mydashboard/components/dashboard/MemberCountText.tsx
@@ -1,0 +1,22 @@
+const MemberCountText = ({ count }: { count: number }) => {
+  // 혼자만 있는 대시보드의 경우 함께할 동료를 추가하라는 메시지 출력
+  if (count === 0) {
+    return (
+      <p className="text-taskify-xs-normal text-taskify-neutral-400 whitespace-nowrap">
+        함께할 동료를 추가해보세요
+      </p>
+    );
+  }
+
+  // 한 명 이상 있을 경우 총 참여중인 사람 수를 출력
+  return (
+    <p className="text-taskify-xs-normal text-taskify-neutral-400 whitespace-nowrap">
+      <span className="text-taskify-xs-medium text-taskify-neutral-500">
+        {count}명
+      </span>
+      이 참여하고 있어요
+    </p>
+  );
+};
+
+export default MemberCountText;

--- a/src/app/mydashboard/components/dashboard/NewDashboard.tsx
+++ b/src/app/mydashboard/components/dashboard/NewDashboard.tsx
@@ -1,0 +1,16 @@
+import { TbClipboardPlus } from 'react-icons/tb';
+
+const NewDashboard = () => {
+  return (
+    <div className="flex items-center justify-center">
+      <div className="flex-col justify-items-center">
+        <TbClipboardPlus className="text-taskify-neutral-300 h-22 w-22" />
+        <p className="text-taskify-neutral-300 mt-3">
+          클릭하여 새로운 대시보드를 만들어 보세요
+        </p>
+      </div>
+    </div>
+  );
+};
+
+export default NewDashboard;

--- a/src/app/mydashboard/components/dashboard/NewDashboardCard.tsx
+++ b/src/app/mydashboard/components/dashboard/NewDashboardCard.tsx
@@ -1,0 +1,32 @@
+'use client';
+
+import { FaPlus } from 'react-icons/fa6';
+
+import CreateDashboardDialog from '@/components/common/dialog/CreateDashboardDialog';
+import { useDialogStore } from '@/stores/useDialogStore';
+
+const NewDashboardCard = () => {
+  const { openDialog } = useDialogStore();
+  return (
+    <div
+      role="button"
+      tabIndex={0}
+      onClick={() => openDialog({ dialogComponent: <CreateDashboardDialog /> })}
+      onKeyDown={(e) => {
+        if (e.key === 'Enter' || e.key === ' ') {
+          openDialog({ dialogComponent: <CreateDashboardDialog /> });
+        }
+      }}
+      className="order-0 flex min-h-[58px] w-[290px] cursor-pointer flex-col items-center justify-center gap-2 rounded-lg border p-3 transition hover:shadow-sm md:min-h-[68px] md:w-[275px] lg:min-h-[170px] lg:w-[170px]"
+    >
+      <div className="flex flex-row items-center gap-2 md:flex-row lg:flex-col">
+        <FaPlus className="text-taskify-neutral-400 h-[15px] w-[15px] md:h-[18px] md:w-[18px] lg:h-[35px] lg:w-[35px]" />
+        <p className="text-taskify-md-regular md:text-taskify-sm-medium sm:text-taskify-xs-normal text-taskify-neutral-400 whitespace-nowrap">
+          새로운 대시보드
+        </p>
+      </div>
+    </div>
+  );
+};
+
+export default NewDashboardCard;

--- a/src/app/mydashboard/components/invitation/NoInvitation.tsx
+++ b/src/app/mydashboard/components/invitation/NoInvitation.tsx
@@ -19,19 +19,3 @@ const NoInvitation = () => {
 };
 
 export default NoInvitation;
-
-// (
-//   <div className="bg-taskify-neutral-0 flex h-[450px] w-[1022px] items-center justify-center rounded-2xl p-6 px-[32px]">
-//     <div className="flex-col justify-items-center">
-//       <Image
-//         src="/images/envelope.png"
-//         alt="초대 없음"
-//         width={87.5}
-//         height={75}
-//       />
-//       <p className="text-taskify-neutral-300">
-//         아직 초대받은 대시보드가 없어요
-//       </p>
-//     </div>
-//   </div>
-// );

--- a/src/app/mydashboard/layout.tsx
+++ b/src/app/mydashboard/layout.tsx
@@ -1,0 +1,21 @@
+import React from 'react';
+
+import Sidebar from '@/components/common/Sidebar';
+
+export const metadata = {
+  title: 'Dashboard | My Next.js App',
+  description: 'Dashboard specific layout',
+};
+
+export default function DashboardLayout({
+  children,
+}: {
+  children: React.ReactNode;
+}) {
+  return (
+    <div className="relative flex min-h-screen">
+      <Sidebar />
+      <main className="flex-1 md:ml-[160px] xl:ml-[300px]">{children}</main>
+    </div>
+  );
+}

--- a/src/app/mydashboard/page.tsx
+++ b/src/app/mydashboard/page.tsx
@@ -1,11 +1,15 @@
+import DashboardSection from './components/dashboard/DashboardSection';
 import InvitationDashboard from './components/invitation/InvitationDashboard';
 
-const mydashboard = () => {
+const Mydashboard = () => {
   return (
     <div className="bg-taskify-neutral-200 min-h-screen">
-      <InvitationDashboard />
+      <div className="ml-6 h-screen flex-col md:ml-3.5 md:block md:h-auto md:pt-20 lg:ml-10 lg:pt-20">
+        <DashboardSection />
+        <InvitationDashboard />
+      </div>
     </div>
   );
 };
 
-export default mydashboard;
+export default Mydashboard;

--- a/src/components/common/dialog/CreateDashboardDialog.tsx
+++ b/src/components/common/dialog/CreateDashboardDialog.tsx
@@ -1,4 +1,4 @@
-import { useMutation } from '@tanstack/react-query';
+import { useMutation, useQueryClient } from '@tanstack/react-query';
 import { ChangeEvent, FormEvent, useState } from 'react';
 
 import { Button } from '@/components/ui/Button';
@@ -17,6 +17,7 @@ import { ColorPickerChip } from '../Chips';
 
 const CreateDashboardDialog = () => {
   const { closeDialog } = useDialogStore();
+  const queryClient = useQueryClient();
 
   const [createDashboardValue, setCreateDashboardValue] = useState<string>('');
   const [selectedColor, setSelectedColor] = useState<string>('#7AC555');
@@ -25,6 +26,7 @@ const CreateDashboardDialog = () => {
     mutationFn: createDashboard,
     onSuccess: () => {
       closeDialog();
+      queryClient.invalidateQueries({ queryKey: ['dashboards'] });
     },
     onError: (error) => {
       console.error('대쉬보드 생성에 실패했습니다.', error.message);


### PR DESCRIPTION
### 🚨 PR 제목 컨벤션 (필수)

- `feat: 새로운 기능 추가`
- `fix: 버그 수정`
- `docs: 문서 변경`
- `chore: 기타 작업`
- `허용된 타입 목록: feat|fix|docs|style|refactor|perf|test|build|ci|chore|revert`
- Linear Issue Key 를 포함해주세요. 예: `LIN-123/feat: 새로운 기능 추가`

## 🪓 관련 Linear Issue

Linear 이슈 링크: https://linear.app/fe16-intermediate-project/issue/LIN-49/새로운-대시보드-관련-컴포넌트-제작

## 💡 변경 사항 요약

- mydashboard 페이지 내 대시보드 관련 컴포넌트를 추가했습니다.

### 📌 세부 변경 내용

- DashboardHeader : 컬러닷 + 대시보드 타이틀로 이뤄진 컴포넌트입니다. 태블릿 사이즈의 경우 호버하면 기존에 노출되던 타이틀이 짧게 축약되며 멤버 아바타가 보입니다. 자신이 만든 대시보드일 경우 왕관 아이콘도 함께 출력됩니다.
- DashboardList : 반응형에 따라 노출되는 목록의 그리드 컬럼 수를 조절하였습니다. 
- DashboardListItem : 개별 대시보드 카드를 관리하는 컴포넌트입니다. 반응형에 따라 포함되는 요소가 다릅니다. PC에서는 헤더 + 멤버 아바타 + 멤버 카운트가 모두 노출되며, 태블릿에서는 헤더 + 호버 시 멤버 아바타, 모바일에서는 헤더만 출력됩니다.
- DashboardSection : 대시보드 최상위 컴포넌트. 기존 대시보드 목록이 없을 시 대시보드를 새롭게 생성할 수 있는 버튼이 출력됩니다.
- MemberAvatars : 대시보드에 참여중인 인원의 아바타를 보여줍니다. 3명까지 보여주고 이후 +rest로 잔여 인원 수를 표기합니다.
- MemberCountText : 대시보드에 참여중인 인원의 숫자를 출력합니다. 혼자 있는 대시보드일 경우 "함께 할 동료를 추가해보세요" 문구가 출력됩니다.
- NewDashboard : 클릭 시 새로운 대시보드를 만들 수 있는 버튼입니다. (DashboardSection)에서 사용
- NewDashboardCard : 대시보드 목록 내 새로운 대시보드를 추가할 수 있는 목록입니다. grid 중 항상 0번 자리에 위치하며, 클릭 시 생성 모달과 연결됩니다.
- layout, page : mydashboard 페이지 내 사이드바를 레이아웃에 추가하고 페이지 내 컴포넌트의 레이아웃을 조정하였습니다.
- CreateDashboardDialog : 대시보드 생성 모달에서 성공적으로 submit 시 모달이 닫히며 대시목록이 새로고침됩니다.
