### PR TITLE
LIN-55/feat: 공용 헤더 제작 및 적용

### DIFF
--- a/src/app/dashboard/[id]/page.tsx
+++ b/src/app/dashboard/[id]/page.tsx
@@ -2,22 +2,53 @@
 
 import { useQuery } from '@tanstack/react-query';
 import { useParams } from 'next/navigation';
+import { useEffect } from 'react';
 
 import { AddCountChip } from '@/components/common/Chips';
 import CreateColumnDialog from '@/components/common/dialog/CreateColumnDialog';
 import Button from '@/components/ui/Buttons';
 import { getColumn } from '@/lib/api/columnService';
+import { getDashboardDetail } from '@/lib/api/dashboardService';
+import { useDashboardStore } from '@/stores/useDashboardStore';
 import { useDialogStore } from '@/stores/useDialogStore';
 import { ColumnResponse } from '@/types/Column';
 
 import ColumnComponent from './components/ColumnComponent';
 
+// 헤더 내 상세페이지 상태 연결(타이틀, 아이디)
 const DashboardIdPage = () => {
   const Prams = useParams();
   const { openDialog } = useDialogStore();
 
   const rawDashboardId = Prams.id as string;
   const dashboardId = Number(rawDashboardId);
+
+  const { dashboardTitle, setDashboardTitle, setDashboardId } =
+    useDashboardStore();
+
+  useEffect(() => {
+    const fetchDashboardTitle = async () => {
+      try {
+        const dashboard = await getDashboardDetail(dashboardId);
+        setDashboardTitle(dashboard.title);
+      } catch (error) {
+        console.error('Failed to fetch dashboard title:', error);
+      }
+    };
+
+    if (dashboardId) {
+      setDashboardId(dashboardId);
+      fetchDashboardTitle();
+    }
+  }, [dashboardId]);
+
+  // 메타데이터 동적 페이지 타이틀 설정
+
+  useEffect(() => {
+    if (dashboardTitle) {
+      document.title = `${dashboardTitle} | Taskify`;
+    }
+  }, [dashboardTitle]);
 
   const { data, isLoading, isError, error } = useQuery<ColumnResponse>({
     queryKey: ['columns', dashboardId],

--- a/src/app/dashboard/layout.tsx
+++ b/src/app/dashboard/layout.tsx
@@ -1,10 +1,11 @@
 import React from 'react';
 
+import Header from '@/components/common/header/Header';
 import Sidebar from '@/components/common/Sidebar';
 
 export const metadata = {
-  title: 'Dashboard | My Next.js App',
-  description: 'Dashboard specific layout',
+  title: 'Dashboard | Taskify',
+  description: '대시보드 상세 페이지입니다.',
 };
 
 export default function DashboardLayout({
@@ -15,7 +16,10 @@ export default function DashboardLayout({
   return (
     <div className="relative flex min-h-screen">
       <Sidebar />
-      <main className="flex-1 md:ml-[160px] xl:ml-[300px]">{children}</main>
+      <Header />
+      <main className="flex-1 md:mt-[90px] md:ml-[160px] xl:ml-[300px]">
+        {children}
+      </main>
     </div>
   );
 }

--- a/src/app/globals.css
+++ b/src/app/globals.css
@@ -207,6 +207,7 @@
   html {
     scroll-behavior: smooth; /* 부드러운 스크롤 */
     -webkit-tap-highlight-color: transparent; /* 모바일 탭 시 하이라이트 제거 */
+    overflow-y: scroll; /*헤더 선택 시 화면 움직임 최소화*/
   }
 
   body {

--- a/src/app/mydashboard/components/dashboard/DashboardHeader.tsx
+++ b/src/app/mydashboard/components/dashboard/DashboardHeader.tsx
@@ -1,0 +1,34 @@
+import Image from 'next/image';
+
+import crownIcon from '@/../public/images/icon/crown.svg';
+
+const DashboardHeader = ({
+  title,
+  color,
+  createdByMe,
+}: {
+  title: string;
+  color: string;
+  createdByMe: boolean;
+}) => (
+  // h2 외곽을 hover하더라도 반영될 수 있게 group 처리
+  <div className="group flex items-center gap-2 md:self-center lg:mt-4 lg:self-auto">
+    {/* 컬러 닷 */}
+    <span
+      className="size-3 shrink-0 rounded-full"
+      style={{ backgroundColor: color }}
+    />
+
+    {/* 타이틀. md에서 hover하면 제목 길이가 짧게 축약되며 아바타 출력 */}
+    <h2 className="text-taskify-lg-medium text-taskify-neutral-600 max-w-[200px] truncate overflow-hidden md:max-w-[180px] md:group-hover:max-w-[100px] lg:max-w-[100px]">
+      {title}
+    </h2>
+
+    {/* 자신이 만든 대시보드일 경우 왕관 아이콘 출력 */}
+    <div className="shrink-0">
+      {createdByMe && <Image src={crownIcon} alt="owner" />}
+    </div>
+  </div>
+);
+
+export default DashboardHeader;

--- a/src/app/mydashboard/components/dashboard/DashboardList.tsx
+++ b/src/app/mydashboard/components/dashboard/DashboardList.tsx
@@ -1,0 +1,74 @@
+'use client';
+
+import { useQuery } from '@tanstack/react-query';
+import { useEffect, useState } from 'react';
+
+import PaginationButton from '@/components/ui/PaginationButton';
+import { Skeleton } from '@/components/ui/skeleton';
+import { getDashboards } from '@/lib/api/dashboardService';
+
+import DashboardListItem from './DashboardListItem';
+import NewDashboardCard from './NewDashboardCard';
+
+const DashboardList = () => {
+  const [page, setPage] = useState(1);
+  const [itemsPerPage, setItemsPerPage] = useState(4);
+
+  const { data, isPending, isError, error } = useQuery({
+    queryKey: ['dashboards', page, itemsPerPage],
+    queryFn: () =>
+      getDashboards({
+        navigationMethod: 'pagination',
+        page,
+        size: itemsPerPage,
+      }),
+    staleTime: 1000 * 60 * 5,
+  });
+
+  // 펜딩과 에러 처리 수정 필요(임시)
+  if (isPending) <Skeleton />;
+  if (isError) <p>에러가 발생했습니다. {error.message}</p>;
+
+  const dashboards = data?.dashboards ?? [];
+
+  // 반응형 크기에 따라 페이지당 출력하는 대시보드 목록 변경하는 로직
+  useEffect(() => {
+    const updateItemsPerPage = () => {
+      const width = window.innerWidth;
+      if (width < 768) {
+        setItemsPerPage(5); // 모바일
+      } else if (width < 1024) {
+        setItemsPerPage(5); // 태블릿
+      } else {
+        setItemsPerPage(4); // 데스크탑
+      }
+    };
+
+    updateItemsPerPage(); // 초기 설정
+    window.addEventListener('resize', updateItemsPerPage);
+    return () => window.removeEventListener('resize', updateItemsPerPage);
+  }, []);
+
+  return (
+    <>
+      <div className="mx-auto w-full max-w-[1000px] px-3 lg:mt-1">
+        <div className="mt-4.5 grid grid-cols-1 gap-2.5 md:grid-cols-2 lg:grid-cols-5">
+          <NewDashboardCard />
+          {dashboards.map((dashboard) => (
+            <DashboardListItem key={dashboard.id} dashboard={dashboard} />
+          ))}
+        </div>
+      </div>
+      <div className="absolute top-[495px] left-[170px] flex justify-center md:top-[388px] md:left-[585px] lg:top-[350px] lg:left-[1145px]">
+        <PaginationButton
+          page={page}
+          size={itemsPerPage}
+          totalCount={data?.totalCount ?? 0}
+          onPageChange={setPage}
+        />
+      </div>
+    </>
+  );
+};
+
+export default DashboardList;

--- a/src/app/mydashboard/components/dashboard/DashboardListItem.tsx
+++ b/src/app/mydashboard/components/dashboard/DashboardListItem.tsx
@@ -1,0 +1,49 @@
+'use client';
+
+import { useRouter } from 'next/navigation';
+
+import { useMemberStore } from '@/stores/useMemberStore';
+import { Dashboard } from '@/types/Dashboard';
+
+import DashboardHeader from './DashboardHeader';
+import MemberAvatars from './MemberAvatars';
+import MemberCountText from './MemberCountText';
+
+interface DashboardListItemProps {
+  dashboard: Dashboard;
+}
+
+const DashboardListItem = ({ dashboard }: DashboardListItemProps) => {
+  const router = useRouter();
+  const members = useMemberStore((state) => state.members);
+
+  // 카드 개별 구성
+  // PC : 헤더 + 멤버아바타 + 멤버카운트, 태블릿 : 헤더 + 호버 시 멤버 아바타, 모바일 : 헤더
+  return (
+    <div
+      role="button"
+      tabIndex={0}
+      onClick={() => router.push(`/dashboard/${dashboard.id}`)}
+      onKeyDown={(e) => {
+        if (e.key === 'Enter' || e.key === ' ') {
+          router.push(`/dashboard/${dashboard.id}`);
+        }
+      }}
+      className="group relative flex min-h-[58px] w-[290px] cursor-pointer flex-col items-start justify-between gap-2 rounded-lg border p-4 transition hover:shadow-sm md:min-h-[68px] md:w-[275px] md:flex-row lg:min-h-[175px] lg:w-[175px] lg:flex-col"
+    >
+      <DashboardHeader
+        title={dashboard.title}
+        color={dashboard.color}
+        createdByMe={dashboard.createdByMe}
+      />
+      <div className="hidden transition-all duration-200 group-hover:opacity-100 md:absolute md:top-5 md:left-44 md:group-hover:block lg:relative lg:top-auto lg:left-auto lg:-mt-6 lg:block">
+        <MemberAvatars />
+      </div>
+      <div className="hidden lg:mb-2 lg:block">
+        <MemberCountText count={members.length} />
+      </div>
+    </div>
+  );
+};
+
+export default DashboardListItem;

--- a/src/app/mydashboard/components/dashboard/DashboardSection.tsx
+++ b/src/app/mydashboard/components/dashboard/DashboardSection.tsx
@@ -1,0 +1,64 @@
+'use client';
+
+import { useQuery } from '@tanstack/react-query';
+
+import CreateDashboardDialog from '@/components/common/dialog/CreateDashboardDialog';
+import { Skeleton } from '@/components/ui/skeleton';
+import { getDashboards } from '@/lib/api/dashboardService';
+import { useDialogStore } from '@/stores/useDialogStore';
+
+import DashboardList from './DashboardList';
+import NewDashboard from './NewDashboard';
+
+// 대시보드 리스트 총괄
+const DashboardSection = () => {
+  const { data, isPending, isError, error } = useQuery({
+    queryKey: ['dashboards'],
+    queryFn: () =>
+      getDashboards({
+        navigationMethod: 'pagination',
+        page: 1,
+        size: 100,
+      }),
+    staleTime: 1000 * 60 * 5,
+  });
+
+  const { openDialog } = useDialogStore();
+
+  if (isPending) return <Skeleton />;
+  if (isError) return <div>에러 발생: {error.message}</div>;
+
+  const hasDashboards = (data?.dashboards?.length ?? 0) > 0;
+
+  // 기존 대시보드 목록이 없을 시 새로운 대시보드 만들 수 있는 버튼 출력
+  return (
+    <div className="bg-taskify-neutral-0 mb-14 flex h-[550px] w-[340px] flex-col rounded-2xl p-6 px-[15px] md:h-[360px] md:w-[620px] lg:h-[330px] lg:w-[1022px]">
+      <h1 className="text-taskify-2xl-bold text-taskify-neutral-700 md:ml-4 lg:ml-4">
+        대시보드
+      </h1>
+      {hasDashboards ? (
+        <DashboardList />
+      ) : (
+        <div
+          role="button"
+          tabIndex={0}
+          className="flex flex-1 cursor-pointer items-center justify-center"
+          onClick={() =>
+            openDialog({
+              dialogComponent: <CreateDashboardDialog />,
+            })
+          }
+          onKeyDown={(e) => {
+            if (e.key === 'Enter' || e.key === ' ') {
+              openDialog({ dialogComponent: <CreateDashboardDialog /> });
+            }
+          }}
+        >
+          <NewDashboard />
+        </div>
+      )}
+    </div>
+  );
+};
+
+export default DashboardSection;

--- a/src/app/mydashboard/components/dashboard/MemberAvatars.tsx
+++ b/src/app/mydashboard/components/dashboard/MemberAvatars.tsx
@@ -1,0 +1,33 @@
+'use client';
+
+import { AvatarProfile } from '@/components/common/Profile';
+import { useMemberStore } from '@/stores/useMemberStore';
+
+const MemberAvatars = () => {
+  const members = useMemberStore((state) => state.getMembers());
+
+  // 아바타는 3명까지만 노출되며 그 이후는 +rest로 처리
+  const visible = members.slice(0, 3);
+  const rest = members.length - visible.length;
+
+  return (
+    <div className="flex">
+      {visible.map((member, idx) => (
+        <div key={member.id} className={idx !== 0 ? '-ml-2' : ''}>
+          <AvatarProfile
+            userName={member.nickname}
+            profileImg={member.profileImageUrl}
+            size="sm"
+          />
+        </div>
+      ))}
+      {rest > 0 && (
+        <div className="bg-muted text-muted-foreground z-10 -ml-2 flex size-[26px] items-center justify-center rounded-full border border-white text-xs font-medium">
+          +{rest}
+        </div>
+      )}
+    </div>
+  );
+};
+
+export default MemberAvatars;

--- a/src/app/mydashboard/components/dashboard/MemberCountText.tsx
+++ b/src/app/mydashboard/components/dashboard/MemberCountText.tsx
@@ -1,0 +1,22 @@
+const MemberCountText = ({ count }: { count: number }) => {
+  // 혼자만 있는 대시보드의 경우 함께할 동료를 추가하라는 메시지 출력
+  if (count === 0) {
+    return (
+      <p className="text-taskify-xs-normal text-taskify-neutral-400 whitespace-nowrap">
+        함께할 동료를 추가해보세요
+      </p>
+    );
+  }
+
+  // 한 명 이상 있을 경우 총 참여중인 사람 수를 출력
+  return (
+    <p className="text-taskify-xs-normal text-taskify-neutral-400 whitespace-nowrap">
+      <span className="text-taskify-xs-medium text-taskify-neutral-500">
+        {count}명
+      </span>
+      이 참여하고 있어요
+    </p>
+  );
+};
+
+export default MemberCountText;

--- a/src/app/mydashboard/components/dashboard/NewDashboard.tsx
+++ b/src/app/mydashboard/components/dashboard/NewDashboard.tsx
@@ -1,0 +1,16 @@
+import { TbClipboardPlus } from 'react-icons/tb';
+
+const NewDashboard = () => {
+  return (
+    <div className="flex items-center justify-center">
+      <div className="flex-col justify-items-center">
+        <TbClipboardPlus className="text-taskify-neutral-300 h-22 w-22" />
+        <p className="text-taskify-neutral-300 mt-3">
+          클릭하여 새로운 대시보드를 만들어 보세요
+        </p>
+      </div>
+    </div>
+  );
+};
+
+export default NewDashboard;

--- a/src/app/mydashboard/components/dashboard/NewDashboardCard.tsx
+++ b/src/app/mydashboard/components/dashboard/NewDashboardCard.tsx
@@ -1,0 +1,32 @@
+'use client';
+
+import { FaPlus } from 'react-icons/fa6';
+
+import CreateDashboardDialog from '@/components/common/dialog/CreateDashboardDialog';
+import { useDialogStore } from '@/stores/useDialogStore';
+
+const NewDashboardCard = () => {
+  const { openDialog } = useDialogStore();
+  return (
+    <div
+      role="button"
+      tabIndex={0}
+      onClick={() => openDialog({ dialogComponent: <CreateDashboardDialog /> })}
+      onKeyDown={(e) => {
+        if (e.key === 'Enter' || e.key === ' ') {
+          openDialog({ dialogComponent: <CreateDashboardDialog /> });
+        }
+      }}
+      className="order-0 flex min-h-[58px] w-[290px] cursor-pointer flex-col items-center justify-center gap-2 rounded-lg border p-3 transition hover:shadow-sm md:min-h-[68px] md:w-[275px] lg:min-h-[170px] lg:w-[170px]"
+    >
+      <div className="flex flex-row items-center gap-2 md:flex-row lg:flex-col">
+        <FaPlus className="text-taskify-neutral-400 h-[15px] w-[15px] md:h-[18px] md:w-[18px] lg:h-[35px] lg:w-[35px]" />
+        <p className="text-taskify-md-regular md:text-taskify-sm-medium sm:text-taskify-xs-normal text-taskify-neutral-400 whitespace-nowrap">
+          새로운 대시보드
+        </p>
+      </div>
+    </div>
+  );
+};
+
+export default NewDashboardCard;

--- a/src/app/mydashboard/components/invitation/NoInvitation.tsx
+++ b/src/app/mydashboard/components/invitation/NoInvitation.tsx
@@ -19,19 +19,3 @@ const NoInvitation = () => {
 };
 
 export default NoInvitation;
-
-// (
-//   <div className="bg-taskify-neutral-0 flex h-[450px] w-[1022px] items-center justify-center rounded-2xl p-6 px-[32px]">
-//     <div className="flex-col justify-items-center">
-//       <Image
-//         src="/images/envelope.png"
-//         alt="초대 없음"
-//         width={87.5}
-//         height={75}
-//       />
-//       <p className="text-taskify-neutral-300">
-//         아직 초대받은 대시보드가 없어요
-//       </p>
-//     </div>
-//   </div>
-// );

--- a/src/app/mydashboard/layout.tsx
+++ b/src/app/mydashboard/layout.tsx
@@ -1,0 +1,21 @@
+import React from 'react';
+
+import Sidebar from '@/components/common/Sidebar';
+
+export const metadata = {
+  title: 'Dashboard | My Next.js App',
+  description: 'Dashboard specific layout',
+};
+
+export default function DashboardLayout({
+  children,
+}: {
+  children: React.ReactNode;
+}) {
+  return (
+    <div className="relative flex min-h-screen">
+      <Sidebar />
+      <main className="flex-1 md:ml-[160px] xl:ml-[300px]">{children}</main>
+    </div>
+  );
+}

--- a/src/app/mydashboard/layout.tsx
+++ b/src/app/mydashboard/layout.tsx
@@ -1,10 +1,12 @@
 import React from 'react';
 
+import Header from '@/components/common/header/Header';
 import Sidebar from '@/components/common/Sidebar';
 
 export const metadata = {
-  title: 'Dashboard | My Next.js App',
-  description: 'Dashboard specific layout',
+  title: 'My Dashboard | Taskify',
+  description:
+    '참여 중인 모든 대시보드와 초대받은 대시보드를 확인하고 관리할 수 있는 페이지입니다.',
 };
 
 export default function DashboardLayout({
@@ -15,6 +17,7 @@ export default function DashboardLayout({
   return (
     <div className="relative flex min-h-screen">
       <Sidebar />
+      <Header />
       <main className="flex-1 md:ml-[160px] xl:ml-[300px]">{children}</main>
     </div>
   );

--- a/src/app/mydashboard/page.tsx
+++ b/src/app/mydashboard/page.tsx
@@ -1,11 +1,15 @@
+import DashboardSection from './components/dashboard/DashboardSection';
 import InvitationDashboard from './components/invitation/InvitationDashboard';
 
-const mydashboard = () => {
+const Mydashboard = () => {
   return (
     <div className="bg-taskify-neutral-200 min-h-screen">
-      <InvitationDashboard />
+      <div className="ml-6 h-screen flex-col md:ml-3.5 md:block md:h-auto md:pt-20 lg:ml-10 lg:pt-20">
+        <DashboardSection />
+        <InvitationDashboard />
+      </div>
     </div>
   );
 };
 
-export default mydashboard;
+export default Mydashboard;

--- a/src/app/mypage/layout.tsx
+++ b/src/app/mypage/layout.tsx
@@ -1,0 +1,26 @@
+import React from 'react';
+
+import Header from '@/components/common/header/Header';
+import Sidebar from '@/components/common/Sidebar';
+
+export const metadata = {
+  title: 'My Page | Taskify',
+  description:
+    '내 정보, 비밀번호 변경, 프로필 사진을 설정할 수 있는 마이페이지입니다.',
+};
+
+export default function MypageLayout({
+  children,
+}: {
+  children: React.ReactNode;
+}) {
+  return (
+    <div className="relative flex min-h-screen">
+      <Sidebar />
+      <Header />
+      <main className="flex-1 md:mt-[90px] md:ml-[160px] xl:ml-[300px]">
+        {children}
+      </main>
+    </div>
+  );
+}

--- a/src/components/common/Profile.tsx
+++ b/src/components/common/Profile.tsx
@@ -59,15 +59,17 @@ export function AvatarProfile({
  * profileImg: 값이 없을 경우, 잘못된 주소가 들어올 경우 AvatarFallback로 넘어갑니다.
  * size: 'sm' (작은 사이즈, 모달에 들어가는 담당자 부분), 'md' (중간 사이즈), 'lg' (큰 사이즈)를 지정합니다. 기본값은 'lg'
  */
+
+// cursor-default -> cursor-pointer, size로 <span> 출력 조건 분기
 export function UserProfile({
   profileImg = null,
   userName = '',
   size = 'lg',
 }: UserProfileProps) {
   return (
-    <div className="flex cursor-default items-center gap-3 text-base">
+    <div className="flex cursor-pointer items-center gap-3 text-base">
       <AvatarProfile profileImg={profileImg} userName={userName} size={size} />
-      <span className="font-medium">{userName}</span>
+      {size !== 'md' && <span className="font-medium">{userName}</span>}
     </div>
   );
 }

--- a/src/components/common/dialog/CreateDashboardDialog.tsx
+++ b/src/components/common/dialog/CreateDashboardDialog.tsx
@@ -1,4 +1,4 @@
-import { useMutation } from '@tanstack/react-query';
+import { useMutation, useQueryClient } from '@tanstack/react-query';
 import { ChangeEvent, FormEvent, useState } from 'react';
 
 import { Button } from '@/components/ui/Button';
@@ -17,6 +17,7 @@ import { ColorPickerChip } from '../Chips';
 
 const CreateDashboardDialog = () => {
   const { closeDialog } = useDialogStore();
+  const queryClient = useQueryClient();
 
   const [createDashboardValue, setCreateDashboardValue] = useState<string>('');
   const [selectedColor, setSelectedColor] = useState<string>('#7AC555');
@@ -25,6 +26,7 @@ const CreateDashboardDialog = () => {
     mutationFn: createDashboard,
     onSuccess: () => {
       closeDialog();
+      queryClient.invalidateQueries({ queryKey: ['dashboards'] });
     },
     onError: (error) => {
       console.error('대쉬보드 생성에 실패했습니다.', error.message);

--- a/src/components/common/header/Header.tsx
+++ b/src/components/common/header/Header.tsx
@@ -1,0 +1,78 @@
+'use client';
+
+import Image from 'next/image';
+import Link from 'next/link';
+import { usePathname } from 'next/navigation';
+
+import MemberAvatars from '@/app/mydashboard/components/dashboard/MemberAvatars';
+import { headerConfig } from '@/lib/constants/headerConfig';
+import { useDashboardStore } from '@/stores/useDashboardStore';
+
+import InviteButton from './InviteButton';
+import ManageButton from './ManageButton';
+import UserAvatar from './UserAvatar';
+
+const DEFAULT_CONFIG = {
+  showUserAvatar: true,
+  showMemberAvatars: false,
+  showInviteButton: false,
+  showManageButton: false,
+};
+
+const Header = () => {
+  // pathname에 따라 headerconfig 조건 분기
+  const pathname = usePathname();
+  const dashboardTitle = useDashboardStore((s) => s.dashboardTitle);
+
+  // headerconfig 기본값 override
+  const matched = headerConfig.find((entry) => entry.match(pathname));
+  const config = {
+    ...DEFAULT_CONFIG,
+    ...(matched?.config ?? {}),
+  };
+
+  // 페이지에 따른 타이틀 override 조건문
+  let headerTitle = '제목 없음';
+  if ('titleFrom' in config) {
+    headerTitle = dashboardTitle;
+  } else if ('title' in config && typeof config.title === 'string') {
+    headerTitle = config.title;
+  }
+
+  return (
+    <header className="border-b-taskify-neutral-300 bg-taskify-neutral-0 fixed z-10 flex h-[60px] w-full items-center justify-between border-[1px]">
+      {/* xl로 우선 지정 -> lg로 논의 후 조건 수정해야함. */}
+      <div className="flex h-full w-full items-center justify-between px-4 md:ml-[160px] md:px-7 xl:ml-[300px]">
+        <div className="flex gap-2">
+          {/* 모바일에서만 로고 보이기 */}
+          <div className="md:hidden">
+            <Link href="/">
+              <Image
+                src="/images/LogoImage.svg"
+                alt="logo"
+                width={23}
+                height={25}
+              />
+            </Link>
+          </div>
+
+          {/* 페이지 타이틀 */}
+          <h1 className="text-taskify-lg-bold lg:text-taskify-xl-bold text-taskify-neutral-700">
+            {headerTitle}
+          </h1>
+        </div>
+        {/* 버튼 요소 */}
+        <div className="flex items-center gap-2">
+          {config.showManageButton && <ManageButton />}
+          {config.showInviteButton && <InviteButton />}
+          {config.showMemberAvatars && <MemberAvatars />}
+          {/* 구분선 */}
+          <div className="bg-taskify-neutral-300 h-8 w-px" />
+          {config.showUserAvatar && <UserAvatar />}
+        </div>
+      </div>
+    </header>
+  );
+};
+
+export default Header;

--- a/src/components/common/header/InviteButton.tsx
+++ b/src/components/common/header/InviteButton.tsx
@@ -1,0 +1,38 @@
+import { CgAddR } from 'react-icons/cg';
+
+import Button from '@/components/ui/Buttons';
+import { useDashboardStore } from '@/stores/useDashboardStore';
+import { useDialogStore } from '@/stores/useDialogStore';
+
+import SendInvitationDialog from '../dialog/SendInvitationDialog';
+
+const InviteButton = () => {
+  // 현재 상세페이지 아이디 담은 초대 모달 열기
+  const currentDashboardId = useDashboardStore((s) => s.dashboardId);
+  const { openDialog } = useDialogStore();
+  if (currentDashboardId == null) return null; // null 또는 undefined 방지
+  console.log('currentDashboardId:', currentDashboardId);
+
+  const handleClick = () =>
+    openDialog({
+      dialogComponent: (
+        <SendInvitationDialog dashboardId={currentDashboardId} />
+      ),
+    });
+
+  return (
+    <Button
+      type="button"
+      color="white-black"
+      onClick={handleClick}
+      className="h-[30px] w-[73px] px-[12px] py-[6px] text-nowrap md:h-[40px] md:w-[116px] md:px-[16px] md:py-[10px]"
+    >
+      <div className="text-taskify-neutral-500 text-taskify-md-medium md:text-taskify-lg-medium flex items-center gap-2">
+        <CgAddR className="hidden md:inline" />
+        <p>초대하기</p>
+      </div>
+    </Button>
+  );
+};
+
+export default InviteButton;

--- a/src/components/common/header/ManageButton.tsx
+++ b/src/components/common/header/ManageButton.tsx
@@ -1,0 +1,27 @@
+import Link from 'next/link';
+import { LuSettings } from 'react-icons/lu';
+
+import Button from '@/components/ui/Buttons';
+import { useDashboardStore } from '@/stores/useDashboardStore';
+
+const ManageButton = () => {
+  const { dashboardId } = useDashboardStore();
+
+  // 대시보드 아이디 받아 관리페이지 link 연결
+  return (
+    <Link href={`/dashboard/${dashboardId}/edit`}>
+      <Button
+        type="button"
+        color="white-black"
+        className="h-[30px] w-[49px] px-[12px] py-[6px] md:h-[40px] md:w-[88px] md:px-[16px] md:py-[10px]"
+      >
+        <div className="text-taskify-md-medium md:text-taskify-lg-medium text-taskify-neutral-500 flex items-center gap-2 text-nowrap">
+          <LuSettings className="hidden md:inline" />
+          <p>관리</p>
+        </div>
+      </Button>
+    </Link>
+  );
+};
+
+export default ManageButton;

--- a/src/components/common/header/UserAvatar.tsx
+++ b/src/components/common/header/UserAvatar.tsx
@@ -1,0 +1,77 @@
+import { useRouter } from 'next/navigation';
+import { useEffect, useState } from 'react';
+
+import {
+  DropdownMenu,
+  DropdownMenuTrigger,
+  DropdownMenuContent,
+  DropdownMenuItem,
+} from '@/components/ui/DropdownMenu';
+import { useAuth } from '@/hooks/useAuth';
+import { useAuthStore } from '@/stores/useAuthStore';
+
+import { UserProfile } from '../Profile';
+
+// 모바일인 경우만 구분
+const useIsMobile = () => {
+  const [isMobile, setIsMobile] = useState(false);
+
+  useEffect(() => {
+    const checkMobile = () => {
+      setIsMobile(window.innerWidth < 768); // Tailwind 기준 md: 768px
+    };
+
+    checkMobile();
+    window.addEventListener('resize', checkMobile);
+    return () => window.removeEventListener('resize', checkMobile);
+  }, []);
+
+  return isMobile;
+};
+
+const UserAvatar = () => {
+  const isMobile = useIsMobile();
+  const user = useAuthStore((state) => state.user);
+  const { logout } = useAuth();
+  const router = useRouter();
+
+  // 임시로 값이 없을 시 처리
+  if (!user) return null;
+
+  return (
+    <DropdownMenu>
+      <DropdownMenuTrigger asChild>
+        <button type="button">
+          <UserProfile
+            userName={user.nickname}
+            profileImg={user.profileImageUrl}
+            size={isMobile ? 'md' : 'lg'}
+          />
+        </button>
+      </DropdownMenuTrigger>
+      <DropdownMenuContent
+        align="end"
+        sideOffset={8}
+        className="z-50"
+        forceMount
+      >
+        <DropdownMenuItem onClick={() => router.push('/mypage')}>
+          내 정보
+        </DropdownMenuItem>
+        <DropdownMenuItem onClick={() => router.push('/mydashboard')}>
+          내 대시보드
+        </DropdownMenuItem>
+        <DropdownMenuItem
+          onClick={() => {
+            logout();
+            router.push('/');
+          }}
+        >
+          로그아웃
+        </DropdownMenuItem>
+      </DropdownMenuContent>
+    </DropdownMenu>
+  );
+};
+
+export default UserAvatar;

--- a/src/lib/api/dashboardService.ts
+++ b/src/lib/api/dashboardService.ts
@@ -50,3 +50,8 @@ export const createInvitations = async ({
   );
   return res.data;
 };
+
+export const getDashboardDetail = async (dashboardId: number) => {
+  const res = await axiosInstance.get(`/dashboards/${dashboardId}`);
+  return res.data;
+};

--- a/src/lib/constants/headerConfig.ts
+++ b/src/lib/constants/headerConfig.ts
@@ -1,0 +1,25 @@
+export const headerConfig = [
+  {
+    match: (pathname: string) => pathname === '/mydashboard',
+    config: {
+      title: '나의 대시보드',
+      showInviteButton: true,
+      showManageButton: true,
+    },
+  },
+  {
+    match: (pathname: string) => pathname.startsWith('/dashboard/'),
+    config: {
+      titleFrom: 'dashboardTitle',
+      showMemberAvatars: true,
+      showInviteButton: true,
+      showManageButton: true,
+    },
+  },
+  {
+    match: (pathname: string) => pathname === '/mypage',
+    config: {
+      title: '계정관리',
+    },
+  },
+];

--- a/src/lib/constants/headerConfig.ts
+++ b/src/lib/constants/headerConfig.ts
@@ -3,8 +3,6 @@ export const headerConfig = [
     match: (pathname: string) => pathname === '/mydashboard',
     config: {
       title: '나의 대시보드',
-      showInviteButton: true,
-      showManageButton: true,
     },
   },
   {

--- a/src/stores/useDashboardStore.ts
+++ b/src/stores/useDashboardStore.ts
@@ -1,0 +1,17 @@
+import { create } from 'zustand';
+
+interface DashboardState {
+  dashboardId: number | undefined;
+  setDashboardId: (id: number) => void;
+
+  dashboardTitle: string;
+  setDashboardTitle: (title: string) => void;
+}
+
+export const useDashboardStore = create<DashboardState>((set) => ({
+  dashboardId: undefined,
+  setDashboardId: (id) => set({ dashboardId: id }),
+
+  dashboardTitle: '',
+  setDashboardTitle: (title) => set({ dashboardTitle: title }),
+}));

--- a/src/types/Dashboard.ts
+++ b/src/types/Dashboard.ts
@@ -19,4 +19,5 @@ export interface DashboardQueryParams {
   cursorId?: number;
   page?: number;
   size?: number;
+  id?: number;
 }


### PR DESCRIPTION
### 🚨 PR 제목 컨벤션 (필수)

- `feat: 새로운 기능 추가`
- `fix: 버그 수정`
- `docs: 문서 변경`
- `chore: 기타 작업`
- `허용된 타입 목록: feat|fix|docs|style|refactor|perf|test|build|ci|chore|revert`
- Linear Issue Key 를 포함해주세요. 예: `LIN-123/feat: 새로운 기능 추가`

## 🪓 관련 Linear Issue

Linear 이슈 링크: https://linear.app/fe16-intermediate-project/issue/LIN-55/공통-header-제작

## 💡 변경 사항 요약

공용 헤더 제작 및 현재 제작된 페이지 레이아웃에 적용하였습니다.

### 📌 세부 변경 내용

- dashboard/[id]/page.tsx : 대시보드 상세페이지 내 타이틀 적용과 메타데이터 헤더 적용을 위해 useEffect 함수를 추가했습니다. 
- globals.css : html 내 overflow-y:scroll 설정을 추가했습니다.
- Header: 공용 헤더 최상위 컴포넌트
- InvitateButton : 헤더 내 초대하기 버튼. 현재 위치한 상세페이지 id를 초대 모달에 담을 수 있게 useDashboardStore 전역 상태관리를 사용하였습니다.
- ManageButton : 헤더 내 관리 버튼. 현재 위치한 대시보드의 관리페이지로 이동합니다. useDashboardStore 사용하였습니다.
- UserAvatar : 헤더 내 유저 아바타. 클릭하면 내 정보, 내 대시보드, 로그아웃을 할 수 있는 드롭다운 메뉴를 제공합니다. 
- Profile : UserProfile 내 cursor-default 값을 cursor-pointer로 수정하였습니다. (헤더에서 hover할 때 클릭할 수 있는 메뉴임을 직관적으로 보여주기 위해 수정하였습니다.) 또 모바일 크기의 경우 유저 아바타 내 <span> 태그를 출력하지 않도록 수정하였습니다.
- dashboardService : 대시보드 상세 조회 api (getDashboardDetail)를 추가하였습니다.
- headerConfig : 페이지 별 헤더 내 구성 요소가 달라, 상수로 관리하기 위해 제작했습니다. pathname을 기준으로 조건 분기하였습니다.
- useDashboardStore : 대시보드 상세 조회 내 대시보드 타이틀과 아이디를 관리하기 위해 전역 스토어를 제작하였습니다. (헤더 내 사용)
- Dashboard(type) : DashboardQueryParams 내 id값을 추가하였습니다.

- PR 전까지 제작된 페이지에는 layout.tsx파일 내 헤더를 적용해두었습니다. 또 메타데이터도 페이지에 맞게 수정하였습니다. 

### 📸 스크린샷 (선택 사항)
<반응형 구현>
1. 상세페이지 PC 사이즈
<img width="1901" height="377" alt="pc" src="https://github.com/user-attachments/assets/8ed66cc8-b903-4462-b2d9-fb884bbecc0e" />

2. 상세페이지 태블릿 사이즈
<img width="1143" height="265" alt="tablet" src="https://github.com/user-attachments/assets/261d90d0-618d-4ad3-9fe3-c7c75e93e540" />

3. 상세페이지 모바일 사이즈
<img width="517" height="420" alt="mobile" src="https://github.com/user-attachments/assets/96d7924b-4aa5-4d9b-9303-adc27b39a22f" />

<페이지 별 헤더 구성 요소 다름>
4. 다른 페이지 헤더
<img width="1884" height="252" alt="mydashboard" src="https://github.com/user-attachments/assets/6684767e-7086-4239-b9aa-4feb40a747fa" />


### ✍️ 추가 코멘트 (선택 사항)

- 헤더에서 드롭다운 메뉴를 클릭할 경우 헤더가 움직이는 현상이 있습니다. html에 overflow-y:scroll을 추가하면 해결된다고 확인하여 추가하였으나, 추가하니 이번에는 본문이 움직입니다.... 추가적으로 해결방법을 찾아보고 수정하겠습니다.
- 피그마 시안에서는 헤더에 모두 페이지타이틀, 관리버튼, 초대하기 버튼, 멤버 아바타, 유저 아바타가 있습니다. 하지만 개별 기능을 생각했을 때 페이지에 맞지 않는 버튼이 있다고 생각하여 페이지별 헤더 구성 요소를 차별 적용하였습니다.
- 일단 사이드바 크기에 맞춰 반응형 xl를 기준으로 헤더 여백을 수정해두었습니다. 반응형 구현 시 lg와 xl의 기준을 다시 논의했으면 합니다.
