### PR TITLE
LIN-61/fix: 다이얼로그 관련 버그 수정 및 카드 수정 모달 연결

### DIFF
--- a/src/components/common/dialog/TaskCardDialog.tsx
+++ b/src/components/common/dialog/TaskCardDialog.tsx
@@ -43,13 +43,13 @@ const TaskCardDialog = ({
     <DialogContent
       className="md:grid-cols-[repeat(4, 1fr)_181px] dialog-scrollable-content grid h-[50vh] max-h-[710px] max-w-[327px] grid-cols-4 gap-4 overflow-auto px-4 md:max-h-[766px] md:max-w-[678px] md:gap-6 md:px-8 lg:max-w-[732px]"
       showCloseButton={false}
-      onOpenAutoFocus={(event) => event.preventDefault()}
     >
       {/** Header 영역 */}
       <DialogHeader className="col-start-1 col-end-5 flex gap-0">
         <TaskCardDialogControlArea
           className="absolute top-5 right-5 flex gap-5"
           cardId={cardId}
+          cardData={data}
         />
         {showSkeleton ? (
           <SkeletonLine
@@ -63,6 +63,7 @@ const TaskCardDialog = ({
             </span>
           </DialogTitle>
         )}
+        <DialogTitle />
         <DialogDescription />
       </DialogHeader>
       {/* CardAuthor 영역 */}

--- a/src/components/common/dialog/dialog-components/TaskCardDialogControlArea.tsx
+++ b/src/components/common/dialog/dialog-components/TaskCardDialogControlArea.tsx
@@ -3,20 +3,23 @@ import { HTMLAttributes } from 'react';
 
 import { DialogClose } from '@/components/ui/Dialog';
 import { useDialogStore } from '@/stores/useDialogStore';
+import DetailCard from '@/types/DetailCard';
 import closeBtn from 'public/images/icon/closeBtn.svg';
 
 import { KebobMenu } from '../../KebobMenu';
-import AlertDialog from '../AlertDialog';
 import ConfirmTaskCardDeletionDialog from '../ConfirmTaskCardDeletionDialog';
+import TodoEditDialog from '../TodoDialog/TodoEditDialog';
 
 interface TaskCardDialogControlAreaProps
   extends HTMLAttributes<HTMLDivElement> {
   cardId: number;
+  cardData: DetailCard | undefined;
 }
 
 const TaskCardDialogControlArea = ({
   className,
   cardId,
+  cardData,
 }: TaskCardDialogControlAreaProps) => {
   const { openDialog } = useDialogStore();
 
@@ -30,10 +33,15 @@ const TaskCardDialogControlArea = ({
             variant: 'default',
             onSelect: () => {
               openDialog({
-                dialogComponent: (
+                dialogComponent:
                   // 할 일 카드 수정 다이얼로그 완성 시 붙여줘야함
-                  <AlertDialog description="test" closeBtnText="확인" />
-                ),
+                  cardData && (
+                    <TodoEditDialog
+                      columnId={cardData.columnId}
+                      mode="edit"
+                      cardData={cardData}
+                    />
+                  ),
               });
             },
           },

--- a/src/components/ui/Dialog.tsx
+++ b/src/components/ui/Dialog.tsx
@@ -18,44 +18,49 @@ const DialogTrigger = ({
   return <DialogPrimitive.Trigger data-slot="dialog-trigger" {...props} />;
 };
 
+// --- DialogPortal 수정: className 제거 및 ref 전달
 const DialogPortal = ({
   ...props
 }: React.ComponentProps<typeof DialogPrimitive.Portal>) => {
   return <DialogPrimitive.Portal data-slot="dialog-portal" {...props} />;
 };
 
+// --- DialogClose는 ref 전달 필요 없음
 const DialogClose = ({
   ...props
 }: React.ComponentProps<typeof DialogPrimitive.Close>) => {
   return <DialogPrimitive.Close data-slot="dialog-close" {...props} />;
 };
 
-const DialogOverlay = ({
-  className,
-  ...props
-}: React.ComponentProps<typeof DialogPrimitive.Overlay>) => (
+// --- DialogOverlay 수정: ref 전달
+const DialogOverlay = React.forwardRef<
+  React.ElementRef<typeof DialogPrimitive.Overlay>,
+  React.ComponentPropsWithoutRef<typeof DialogPrimitive.Overlay>
+>(({ className, ...props }, ref) => (
   <DialogPrimitive.Overlay
     data-slot="dialog-overlay"
+    ref={ref}
     className={cn(
       'data-[state=open]:animate-in data-[state=closed]:animate-out data-[state=closed]:fade-out-0 data-[state=open]:fade-in-0 fixed inset-0 z-50 bg-black/50',
       className,
     )}
     {...props}
   />
-);
+));
+DialogOverlay.displayName = DialogPrimitive.Overlay.displayName;
 
-const DialogContent = ({
-  className,
-  children,
-  showCloseButton = true,
-  ...props
-}: React.ComponentProps<typeof DialogPrimitive.Content> & {
-  showCloseButton?: boolean;
-}) => (
+// --- DialogContent 수정: ref 전달
+const DialogContent = React.forwardRef<
+  React.ElementRef<typeof DialogPrimitive.Content>,
+  React.ComponentPropsWithoutRef<typeof DialogPrimitive.Content> & {
+    showCloseButton?: boolean;
+  }
+>(({ className, children, showCloseButton = true, ...props }, ref) => (
   <DialogPortal data-slot="dialog-portal">
     <DialogOverlay />
     <DialogPrimitive.Content
       data-slot="dialog-content"
+      ref={ref} // ref를 DialogPrimitive.Content에 전달
       className={cn(
         'bg-background data-[state=closed]:fade-out-0 data-[state=open]:fade-in-0 data-[state=closed]:zoom-out-95 data-[state=open]:zoom-in-95 data-[state=open]:animate-in data-[state=closed]:animate-out fixed top-[50%] left-[50%] z-50 grid w-full max-w-[calc(100%-2rem)] translate-x-[-50%] translate-y-[-50%] gap-4 rounded-lg border p-6 shadow-lg duration-200 sm:max-w-lg',
         className,
@@ -74,8 +79,10 @@ const DialogContent = ({
       )}
     </DialogPrimitive.Content>
   </DialogPortal>
-);
+));
+DialogContent.displayName = DialogPrimitive.Content.displayName;
 
+// --- DialogHeader는 ref 전달 필요 없음
 const DialogHeader = ({ className, ...props }: React.ComponentProps<'div'>) => {
   return (
     <div
@@ -86,6 +93,7 @@ const DialogHeader = ({ className, ...props }: React.ComponentProps<'div'>) => {
   );
 };
 
+// --- DialogFooter는 ref 전달 필요 없음
 const DialogFooter = ({ className, ...props }: React.ComponentProps<'div'>) => {
   return (
     <div
@@ -99,31 +107,33 @@ const DialogFooter = ({ className, ...props }: React.ComponentProps<'div'>) => {
   );
 };
 
-const DialogTitle = ({
-  className,
-  ...props
-}: React.ComponentProps<typeof DialogPrimitive.Title>) => {
-  return (
-    <DialogPrimitive.Title
-      data-slot="dialog-title"
-      className={cn('text-lg leading-none font-semibold', className)}
-      {...props}
-    />
-  );
-};
+// --- DialogTitle 수정: ref 전달
+const DialogTitle = React.forwardRef<
+  React.ElementRef<typeof DialogPrimitive.Title>,
+  React.ComponentPropsWithoutRef<typeof DialogPrimitive.Title>
+>(({ className, ...props }, ref) => (
+  <DialogPrimitive.Title
+    data-slot="dialog-title"
+    ref={ref} // ref를 DialogPrimitive.Title에 전달
+    className={cn('text-lg leading-none font-semibold', className)}
+    {...props}
+  />
+));
+DialogTitle.displayName = DialogPrimitive.Title.displayName;
 
-const DialogDescription = ({
-  className,
-  ...props
-}: React.ComponentProps<typeof DialogPrimitive.Description>) => {
-  return (
-    <DialogPrimitive.Description
-      data-slot="dialog-description"
-      className={cn('text-muted-foreground text-sm', className)}
-      {...props}
-    />
-  );
-};
+// --- DialogDescription 수정: ref 전달
+const DialogDescription = React.forwardRef<
+  React.ElementRef<typeof DialogPrimitive.Description>,
+  React.ComponentPropsWithoutRef<typeof DialogPrimitive.Description>
+>(({ className, ...props }, ref) => (
+  <DialogPrimitive.Description
+    data-slot="dialog-description"
+    ref={ref} // ref를 DialogPrimitive.Description에 전달
+    className={cn('text-muted-foreground text-sm', className)}
+    {...props}
+  />
+));
+DialogDescription.displayName = DialogPrimitive.Description.displayName;
 
 export {
   Dialog,

--- a/src/stores/useDialogStore.tsx
+++ b/src/stores/useDialogStore.tsx
@@ -73,9 +73,13 @@ export const useDialogStore = create<DialogState>((set) => ({
   closeDialog: () => {
     set({
       isOpen: false,
-      dialogComponent: null,
       stateHistory: [],
     });
+    setTimeout(() => {
+      set({
+        dialogComponent: null,
+      });
+    }, 200);
   },
 
   goBack: () => {


### PR DESCRIPTION
### 🚨 PR 제목 컨벤션 (필수)

- `feat: 새로운 기능 추가`
- `fix: 버그 수정`
- `docs: 문서 변경`
- `chore: 기타 작업`
- `허용된 타입 목록: feat|fix|docs|style|refactor|perf|test|build|ci|chore|revert`
- Linear Issue Key 를 포함해주세요. 예: `LIN-123/feat: 새로운 기능 추가`

## 🪓 관련 Linear Issue

Linear 이슈 링크: [LIN-61: Dialog 버그 수정](https://linear.app/fe16-intermediate-project/issue/LIN-61/dialog-버그-수정)

## 💡 변경 사항 요약

버그 수정

### 📌 세부 변경 내용

- forwardRef 관련 버그
- Warnning: Blocked aria-hidden on an element because its descendant retained focus. => autoFocusing 관련 설정 변경해서 수정했습니다.
- 닫기 애니메이션이 안되는 것 수정 - dialogComponent 를 바로 null로 명시적으로 변경하니 자체적인 닫기 애니메이션이 적용 안되었습니다.

### ✍️ 추가 코멘트 (선택 사항)

- form 내부 form 호출 금지 (ColorPicker 내부 form요소) 제 영역이 아니라 우선 이슈로 공유만 해놨습니다.
