### PR TITLE
LIN-57/feat: 로그인 페이지 연결 및 인증 시 리다이렉트

### DIFF
--- a/src/app/components/LandingHeader.tsx
+++ b/src/app/components/LandingHeader.tsx
@@ -1,0 +1,36 @@
+'use client';
+
+import clsx from 'clsx';
+import { useRouter, usePathname } from 'next/navigation';
+import { HTMLAttributes, useEffect } from 'react';
+
+import { useAuthStore } from '@/stores/useAuthStore';
+
+// interface LandingHeaderProps extends HTMLAttributes<HTMLDivElement> {}
+
+const LandingHeader = ({ className }: HTMLAttributes<HTMLDivElement>) => {
+  const { isAuth } = useAuthStore();
+  const router = useRouter();
+  const pathname = usePathname();
+
+  useEffect(() => {
+    if (isAuth === true && pathname === '/') {
+      router.replace('/mydashboard');
+    }
+  }, [isAuth, router, pathname]);
+
+  return (
+    pathname === '/' && (
+      <header
+        className={clsx(
+          'bg-taskify-neutral-900 text-taskify-neutral-0 text-center',
+          className,
+        )}
+      >
+        header
+      </header>
+    )
+  );
+};
+
+export default LandingHeader;

--- a/src/app/layout.tsx
+++ b/src/app/layout.tsx
@@ -5,6 +5,7 @@ import './globals.css';
 import { GlobalDialog } from '@/components/common/dialog/GlobalDialog';
 import QueryProviders from '@/lib/QueryProvider';
 
+import LandingHeader from './components/LandingHeader';
 import pretendard from '../lib/utils/fonts/pretendard';
 
 export const metadata: Metadata = {
@@ -20,6 +21,7 @@ export default function RootLayout({
   return (
     <html lang="ko">
       <body className={pretendard.variable}>
+        <LandingHeader />
         <QueryProviders>
           {children}
           <GlobalDialog />

--- a/src/app/page.tsx
+++ b/src/app/page.tsx
@@ -35,7 +35,7 @@ export default function Home() {
             </h1>
           </div>
           <div className="col-span-3 mt-25 md:mt-22 xl:mt-23">
-            <Link href="/">
+            <Link href="/login">
               <Button className="h-[46px] w-[235px] md:h-[54px] md:w-[280px]">
                 <span className="text-taskify-md-medium md:text-taskify-2lg-medium">
                   로그인하기


### PR DESCRIPTION
### 🚨 PR 제목 컨벤션 (필수)

- `feat: 새로운 기능 추가`
- `fix: 버그 수정`
- `docs: 문서 변경`
- `chore: 기타 작업`
- `허용된 타입 목록: feat|fix|docs|style|refactor|perf|test|build|ci|chore|revert`
- Linear Issue Key 를 포함해주세요. 예: `LIN-123/feat: 새로운 기능 추가`

## 🪓 관련 Linear Issue

Linear 이슈 링크: [LIN-57: 랜딩페이지 구현](https://linear.app/fe16-intermediate-project/issue/LIN-57/랜딩페이지-구현)

## 💡 변경 사항 요약

로그인 페이지 연결 및 인증 시 리다이렉트

### 📸 스크린샷 (선택 사항)

### ✍️ 추가 코멘트 (선택 사항)

- 동작은 잘 하는데, useAuthStore 훅을 사용하려면 클라이언트 컴포넌트여야 해서 서버 사이드에서 리다이렉트를 시킬 수가 없어서 화면이 깜빡거리네요.
- 서버 사이드 리다이렉트로 변경하면 해당 문제는 사라질 것 같습니다.
- 작업 현황 공유의 편의성을 위해 일단은 PR 올려두겠습니다. 
