### PR TITLE
LIN-59/feat: [대시보드 수정, 마이 페이지] 스켈레톤 UI / 팀 구성원일 때 대시보드 수정 페이지 이동 막음

### DIFF
--- a/src/app/dashboard/[dashboardId]/edit/components/DashboardInvitations.tsx
+++ b/src/app/dashboard/[dashboardId]/edit/components/DashboardInvitations.tsx
@@ -7,98 +7,115 @@ import { ContentSectionWithAction } from '@/components/common/ContentSection';
 import SendInvitationDialog from '@/components/common/dialog/SendInvitationDialog';
 import Button from '@/components/ui/Buttons';
 import PaginationButton from '@/components/ui/PaginationButton';
+import SkeletonLine from '@/components/ui/SkeletonLIne';
 import {
   useDashboardInvitations,
   useDeleteInvitation,
 } from '@/hooks/useDashboardInvitations';
+import { useSkeleton } from '@/hooks/useSkeleton';
 import { useDialogStore } from '@/stores/useDialogStore';
 
-// 페이지 옮긴 뒤 초대 삭제 하면 전 페이지로 안 넘어가고 현재 페이지에서 초대가 없다고 뜸...
 export default function DashboardInvitations({
   dashboardId,
+  isSkeletonVisible,
 }: {
   dashboardId: number;
+  isSkeletonVisible: boolean;
 }) {
   const { openDialog } = useDialogStore();
   const [page, setPage] = useState(1);
   const size = 5;
 
   // 초대 목록
-  const { data, isPending, isError } = useDashboardInvitations(dashboardId, {
+  const { data } = useDashboardInvitations(dashboardId, {
     page,
     size,
   });
 
+  const { showSkeleton, isFadingOut } = useSkeleton(isSkeletonVisible, 1200);
+
   // 초대 삭제
   const deleteMutation = useDeleteInvitation(dashboardId);
 
-  if (isPending) return <p>불러오는 중...</p>;
-  if (isError) return <p>에러 발생!</p>;
-
   return (
     <ContentSectionWithAction
-      // 16px20px
-      className="dashboard-section-action-item4 min-h-[395px] !pb-[16px] sm:min-h-[469px] sm:!pb-[20px]"
-      title="초대 내역"
+      className="dashboard-section-action-item !pb-[16px] sm:!pb-[20px]"
+      title={
+        showSkeleton ? (
+          <SkeletonLine className="h-10 w-[100%]" isFadingOut={isFadingOut} />
+        ) : (
+          '초대 내역'
+        )
+      }
       titleRight={
-        <>
-          {/* <div className="items-center gap-4"></div> */}
-          <PaginationButton
-            className="ml-auto"
-            page={page}
-            size={size}
-            totalCount={data?.totalCount}
-            onPageChange={setPage}
-          />
-          {/* direction: column */}
-          <Button
-            color="violet-white"
-            className="col-start-2 row-start-2 h-[26px] gap-2 justify-self-end !rounded-[4px] px-3 text-[12px] sm:col-start-3 sm:row-start-1 sm:h-[32px] sm:px-4 sm:!text-[14px]"
-            onClick={() =>
-              openDialog({
-                dialogComponent: (
-                  <SendInvitationDialog dashboardId={dashboardId} />
-                ),
-              })
-            }
-          >
-            <Image
-              src="/images/icon/addBox-white.svg"
-              alt="초대하기"
-              height={16}
-              width={16}
+        showSkeleton ? (
+          <SkeletonLine className="h-10 w-[135px]" isFadingOut={isFadingOut} />
+        ) : (
+          <>
+            <PaginationButton
+              className="ml-auto"
+              page={page}
+              size={size}
+              totalCount={data?.totalCount}
+              onPageChange={setPage}
             />
-            <span>초대하기</span>
-          </Button>
-          <h2 className="col-start-1 row-start-2 text-base text-[var(--gray-D9D9D9)] sm:text-[16px]">
-            이메일
-          </h2>
-        </>
+            <Button
+              color="violet-white"
+              className="col-start-2 row-start-2 h-[26px] gap-2 justify-self-end !rounded-[4px] px-3 text-[12px] sm:col-start-3 sm:row-start-1 sm:h-[32px] sm:px-4 sm:!text-[14px]"
+              onClick={() =>
+                openDialog({
+                  dialogComponent: (
+                    <SendInvitationDialog dashboardId={dashboardId} />
+                  ),
+                })
+              }
+            >
+              <Image
+                src="/images/icon/addBox-white.svg"
+                alt="초대하기"
+                height={16}
+                width={16}
+              />
+              <span>초대하기</span>
+            </Button>
+            <h2 className="col-start-1 row-start-2 text-base text-[var(--gray-D9D9D9)] sm:text-[16px]">
+              이메일
+            </h2>
+          </>
+        )
       }
     >
-      <ul className="divide-y">
-        {data?.invitations.length ? (
-          data.invitations.map((invitation) => (
-            <li
-              key={invitation.id}
-              className="flex items-center justify-between px-[20px] py-[12px] last:pb-0 sm:px-[28px] sm:py-[16px]"
-            >
-              <span className="text-[14px] sm:text-[16px]">
-                {invitation.invitee.email}
-              </span>
-              <Button
-                onClick={() => deleteMutation.mutate(invitation.id)}
-                color="white-violet"
-                className="btn-one !rounded-[4px] border border-[var(--gray-D9D9D9)] text-[12px] sm:!text-[14px]"
-              >
-                취소
-              </Button>
-            </li>
-          ))
+      <div className="h-[273px] sm:h-[310px]">
+        {showSkeleton ? (
+          <div className="h-full px-[20px] sm:px-[28px]">
+            <SkeletonLine className="h-full w-full" isFadingOut={isFadingOut} />
+          </div>
         ) : (
-          <p>보낸 초대가 없습니다.</p>
+          <ul className="divide-y">
+            {data?.invitations.length ? (
+              data.invitations.map((invitation) => (
+                <li
+                  key={invitation.id}
+                  className="flex items-center justify-between px-[20px] py-[12px] last:pb-0 sm:px-[28px] sm:py-[16px]"
+                >
+                  <span className="text-[14px] sm:text-[16px]">
+                    {invitation.invitee.email}
+                  </span>
+                  <Button
+                    onClick={() => deleteMutation.mutate(invitation.id)}
+                    color="white-violet"
+                    className="btn-one !rounded-[4px] border border-[var(--gray-D9D9D9)] text-[12px] sm:!text-[14px]"
+                  >
+                    취소
+                  </Button>
+                </li>
+              ))
+            ) : (
+              <p>보낸 초대가 없습니다.</p>
+            )}
+          </ul>
         )}
-      </ul>
+      </div>
     </ContentSectionWithAction>
   );
 }

--- a/src/app/dashboard/[dashboardId]/edit/components/DashboardMembers.tsx
+++ b/src/app/dashboard/[dashboardId]/edit/components/DashboardMembers.tsx
@@ -5,78 +5,102 @@ import { ContentSectionWithAction } from '@/components/common/ContentSection';
 import { UserProfile } from '@/components/common/Profile';
 import Button from '@/components/ui/Buttons';
 import PaginationButton from '@/components/ui/PaginationButton';
+import SkeletonLine from '@/components/ui/SkeletonLIne';
 import {
   useDashboardMember,
   useDeleteMember,
 } from '@/hooks/useDashboardMember';
+import { useSkeleton } from '@/hooks/useSkeleton';
+// import { useDashboard } from '@/hooks/useDashboardEdit';
 
 export default function DashboardMembers({
   dashboardId,
+  isSkeletonVisible,
 }: {
   dashboardId: number;
+  isSkeletonVisible: boolean;
 }) {
   const [page, setPage] = useState(1);
   const size = 4;
 
-  const { data, isPending, isError } = useDashboardMember({
+  const { data } = useDashboardMember({
     page,
     size,
     dashboardId,
   });
 
-  const deleteMutation = useDeleteMember();
+  // const { isPending, isError } = useDashboard(dashboardId);
 
-  if (isPending) return <p>로딩 중...</p>;
-  // 404 페이지와 함께 모달 띄우기
-  if (isError) return <p>실패...</p>;
+  const { showSkeleton, isFadingOut } = useSkeleton(isSkeletonVisible, 1200);
+
+  const deleteMutation = useDeleteMember();
 
   return (
     <ContentSectionWithAction
-      className="dashboard-section-action-item2 min-h-[401px] !pb-[16px] sm:min-h-[410px] sm:!pb-[20px]"
-      title="구성원"
+      className="dashboard-section-action-item !pb-[16px] sm:!pb-[20px]"
+      title={
+        showSkeleton ? (
+          <SkeletonLine className="h-10 w-[100%]" isFadingOut={isFadingOut} />
+        ) : (
+          '구성원'
+        )
+      }
       titleRight={
-        <PaginationButton
-          page={page}
-          size={size}
-          totalCount={data?.totalCount}
-          onPageChange={setPage}
-        />
+        showSkeleton ? (
+          <SkeletonLine className="h-10 w-[135px]" isFadingOut={isFadingOut} />
+        ) : (
+          <PaginationButton
+            page={page}
+            size={size}
+            totalCount={data?.totalCount}
+            onPageChange={setPage}
+          />
+        )
       }
     >
-      <h2 className="mt-[18px] px-[20px] text-base text-[var(--gray-D9D9D9)] sm:mt-[27px] sm:px-[28px] sm:text-[16px]">
-        이름
-      </h2>
-      <ul className="divide-y">
-        {data?.members.map((member) => (
-          <li
-            key={member.id}
-            className="flex items-center justify-between px-[20px] py-[12px] last:pb-0 sm:px-[28px] sm:py-[16px]"
-          >
-            {/* 반응형 사이즈 확인 */}
-            <UserProfile
-              profileImg={member.profileImageUrl}
-              userName={member.nickname}
-            />
-            {!member.isOwner ? (
-              <Button
-                // 경고 모달창 추가하기
-                onClick={() => deleteMutation.mutate(member.id)}
-                color="white-violet"
-                className="btn-one !rounded-[4px] border border-[var(--gray-D9D9D9)] text-[12px] sm:!text-[14px]"
-              >
-                삭제
-              </Button>
-            ) : (
-              <Image
-                src="/images/icon/crown.svg"
-                alt="방장"
-                width={20}
-                height={20}
-              />
-            )}
-          </li>
-        ))}
-      </ul>
+      <div className="mt-[18px] h-[264px] sm:mt-[27px] sm:h-[291px]">
+        {showSkeleton ? (
+          <div className="h-full px-[20px] sm:px-[28px]">
+            <SkeletonLine className="h-full w-full" isFadingOut={isFadingOut} />
+          </div>
+        ) : (
+          <>
+            <h2 className="px-[20px] text-base text-[var(--gray-D9D9D9)] sm:px-[28px] sm:text-[16px]">
+              이름
+            </h2>
+            <ul className="divide-y">
+              {data?.members.map((member) => (
+                <li
+                  key={member.id}
+                  className="flex items-center justify-between px-[20px] py-[12px] last:pb-0 sm:px-[28px] sm:py-[16px]"
+                >
+                  <UserProfile
+                    profileImg={member.profileImageUrl}
+                    userName={member.nickname}
+                  />
+                  {!member.isOwner ? (
+                    <Button
+                      // 경고 모달창 추가하기
+                      onClick={() => deleteMutation.mutate(member.id)}
+                      color="white-violet"
+                      className="btn-one !rounded-[4px] border border-[var(--gray-D9D9D9)] text-[12px] sm:!text-[14px]"
+                    >
+                      삭제
+                    </Button>
+                  ) : (
+                    <Image
+                      src="/images/icon/crown.svg"
+                      alt="방장"
+                      width={20}
+                      height={20}
+                    />
+                  )}
+                </li>
+              ))}
+            </ul>
+          </>
+        )}
+      </div>
     </ContentSectionWithAction>
   );
 }

--- a/src/app/dashboard/[dashboardId]/edit/components/DashboardUpdate.tsx
+++ b/src/app/dashboard/[dashboardId]/edit/components/DashboardUpdate.tsx
@@ -7,12 +7,10 @@ import { ColorPickerChip } from '@/components/common/Chips';
 import { ContentSection } from '@/components/common/ContentSection';
 import Input from '@/components/common/Input';
 import Button from '@/components/ui/Buttons';
+import SkeletonLine from '@/components/ui/SkeletonLIne';
 import { useDashboard, useUpdateDashboard } from '@/hooks/useDashboardEdit';
+import { useSkeleton } from '@/hooks/useSkeleton';
 import { dashboardTitleValidation } from '@/lib/validationRules';
-
-// import { useDialogStore } from '@/stores/useDialogStore';
-// import AlertDialog from '@/components/common/dialog/AlertDialog';
-// import { useRouter } from 'next/navigation';
 
 type FormValues = {
   dashboardTitle: string;
@@ -21,14 +19,12 @@ type FormValues = {
 // 값이 공백으로 들어갈 때 처리 하기
 export default function DashboardUpdate({
   dashboardId,
+  isSkeletonVisible,
 }: {
   dashboardId: number;
+  isSkeletonVisible: boolean;
 }) {
-  // const { openDialog } = useDialogStore();
-
   const [color, setColor] = useState('');
-
-  // const router = useRouter();
 
   const {
     register,
@@ -40,16 +36,11 @@ export default function DashboardUpdate({
     reValidateMode: 'onBlur', // 블러 시에도 다시 검사
   });
 
-  const { data, isPending, isError } = useDashboard(dashboardId);
-  // console.log(isError);
+  const { data } = useDashboard(dashboardId);
+
+  const { showSkeleton, isFadingOut } = useSkeleton(isSkeletonVisible, 1200);
 
   const mutation = useUpdateDashboard(dashboardId);
-
-  // const { isError } = useDashboard(id);
-
-  // if (!isError) {
-  //   router.push('/mydashboard');
-  // }
 
   useEffect(() => {
     // 대시보드가 정상적으로 로드 됐을 때
@@ -66,33 +57,50 @@ export default function DashboardUpdate({
     mutation.mutate({ title, color });
   };
 
-  if (isPending) return <p>로딩 중...</p>;
-  // 404 페이지와 함께 모달 띄우기
-  if (isError) return <p>실패...</p>;
-
   return (
-    <ContentSection title={data.title}>
-      <Input
-        className="dashboard-update-title mt-[24px]"
-        label="대시보드 이름"
-        type="text"
-        placeholder="대시보드 이름을 적어주세요"
-        isError={!!errors.dashboardTitle}
-        isSuccess={dirtyFields.dashboardTitle && !errors.dashboardTitle}
-        errorMessage={errors.dashboardTitle?.message}
-        {...register('dashboardTitle', dashboardTitleValidation)}
-      />
-      <div className="mt-[16px] mb-[40px]">
-        <ColorPickerChip value={color} onChange={setColor} size="md" />
+    <ContentSection
+      title={
+        showSkeleton ? (
+          <SkeletonLine className="h-10 w-full" isFadingOut={isFadingOut} />
+        ) : (
+          data?.title
+        )
+      }
+    >
+      <div className="mt-[24px] mb-[40px]">
+        {showSkeleton ? (
+          <SkeletonLine className="h-32 w-full" isFadingOut={isFadingOut} />
+        ) : (
+          <>
+            <Input
+              className="dashboard-update-title"
+              label="대시보드 이름"
+              type="text"
+              placeholder="대시보드 이름을 적어주세요"
+              isError={!!errors.dashboardTitle}
+              isSuccess={dirtyFields.dashboardTitle && !errors.dashboardTitle}
+              errorMessage={errors.dashboardTitle?.message}
+              {...register('dashboardTitle', dashboardTitleValidation)}
+            />
+            <div className="mt-[16px]">
+              <ColorPickerChip value={color} onChange={setColor} size="md" />
+            </div>
+          </>
+        )}
       </div>
-      <Button
-        color="violet-white"
-        className="h-[54px] w-full"
-        onClick={handleSubmit(handleUpdate)}
-        disabled={!isValid || isSubmitting}
-      >
-        변경
-      </Button>
+
+      {showSkeleton ? (
+        <SkeletonLine className="h-13 w-full" isFadingOut={isFadingOut} />
+      ) : (
+        <Button
+          color="violet-white"
+          className="h-[54px] w-full"
+          onClick={handleSubmit(handleUpdate)}
+          disabled={!isValid || isSubmitting}
+        >
+          변경
+        </Button>
+      )}
     </ContentSection>
   );
 }

--- a/src/app/dashboard/[dashboardId]/edit/page.tsx
+++ b/src/app/dashboard/[dashboardId]/edit/page.tsx
@@ -6,6 +6,8 @@ import { notFound, useParams } from 'next/navigation';
 
 import ConfirmDashboardDeletionDialog from '@/components/common/dialog/ConfirmDashboardDeletionDialog';
 import Button from '@/components/ui/Buttons';
+import { useDashboard } from '@/hooks/useDashboardEdit';
+import { useDashboardInvitations } from '@/hooks/useDashboardInvitations';
 import { useDialogStore } from '@/stores/useDialogStore';
 
 import DashboardInvitations from './components/DashboardInvitations';
@@ -22,6 +24,19 @@ export default function DashboardEditPage() {
   if (Number.isNaN(id)) {
     notFound();
   }
+
+  const page = 0;
+  const size = 0;
+
+  const { isPending: dashboardPending, isError: dashboardError } =
+    useDashboard(id);
+  const { isError: invitationError } = useDashboardInvitations(id, {
+    page,
+    size,
+  });
+
+  const isSkeletonVisible =
+    dashboardPending || dashboardError || invitationError;
 
   return (
     <div className="min-h-screen bg-[var(--gray-FAFAFA)] p-[20px]">
@@ -42,13 +57,19 @@ export default function DashboardEditPage() {
       </nav>
 
       {/* 대시보드 타이틀, 컬러 수정 */}
-      <DashboardUpdate dashboardId={id} />
+      <DashboardUpdate dashboardId={id} isSkeletonVisible={isSkeletonVisible} />
 
       {/* 구성원 */}
-      <DashboardMembers dashboardId={id} />
+      <DashboardMembers
+        dashboardId={id}
+        isSkeletonVisible={isSkeletonVisible}
+      />
 
       {/* 초대 내역 */}
-      <DashboardInvitations dashboardId={id} />
+      <DashboardInvitations
+        dashboardId={id}
+        isSkeletonVisible={isSkeletonVisible}
+      />
 
       {/*  대시보드 삭제하기 */}
       <Button

--- a/src/app/dashboard/[dashboardId]/layout.tsx
+++ b/src/app/dashboard/[dashboardId]/layout.tsx
@@ -11,8 +11,10 @@ export default function DashboardLayout({
   children: React.ReactNode;
 }) {
   return (
-    <div className="flex h-screen xl:overflow-hidden">
-      <main className="flex h-full shrink-0 grow flex-nowrap overflow-x-auto px-0 xl:overflow-y-hidden">
+    <div className="">
+      {/* flex h-screen xl:overflow-hidden */}
+      <main className="">
+        {/* flex h-full shrink-0 grow flex-nowrap overflow-x-auto px-0 xl:overflow-y-hidden */}
         {children}
       </main>
     </div>

--- a/src/app/dashboard/[dashboardId]/layout.tsx
+++ b/src/app/dashboard/[dashboardId]/layout.tsx
@@ -11,10 +11,8 @@ export default function DashboardLayout({
   children: React.ReactNode;
 }) {
   return (
-    <div className="">
-      {/* flex h-screen xl:overflow-hidden */}
-      <main className="">
-        {/* flex h-full shrink-0 grow flex-nowrap overflow-x-auto px-0 xl:overflow-y-hidden */}
+    <div className="flex h-screen xl:overflow-hidden">
+      <main className="flex h-full shrink-0 grow flex-nowrap overflow-x-auto px-0 xl:overflow-y-hidden">
         {children}
       </main>
     </div>

--- a/src/app/globals.css
+++ b/src/app/globals.css
@@ -330,12 +330,12 @@
     @apply !text-[14px] sm:!text-[16px];
   }
 
-  .dashboard-section-action-item2 > div {
+  /* .dashboard-section-action-item2 > div.class-flex {
     @apply flex items-center justify-between;
-  }
+  } */
 
-  .dashboard-section-action-item4 > div {
-    @apply grid grid-cols-[1fr_auto] items-center gap-x-4 gap-y-3 sm:grid-cols-[auto_1fr_auto] sm:gap-y-[32px];
+  .dashboard-section-action-item > div.class-grid {
+    @apply grid grid-cols-[1fr_auto] items-center gap-x-4 gap-y-3 sm:grid-cols-[1fr_auto] sm:gap-y-[32px];
   }
 
   /* 마이페이지 이메일 인풋 스타일 */
@@ -345,12 +345,6 @@
   .input-email input {
     @apply text-[var(--gray-9FA6B2)];
   }
-  /* .input-style label {
-    @apply text-[14px];
-  }
-  .input-style input {
-    @apply text-[16px];
-  } */
 
   /* Dialog Scroll bar */
   /* 1. 스크롤바 트랙 (스크롤바 배경) */

--- a/src/app/mypage/components/MyInfoPassword.tsx
+++ b/src/app/mypage/components/MyInfoPassword.tsx
@@ -4,7 +4,7 @@ import { ContentSection } from '@/components/common/ContentSection';
 import Input from '@/components/common/Input';
 import Button from '@/components/ui/Buttons';
 import SkeletonLine from '@/components/ui/SkeletonLIne';
-import { useChangePassword, useMyInfo } from '@/hooks/useMyInfoEdit';
+import { useChangePassword } from '@/hooks/useMyInfoEdit';
 import { useSkeleton } from '@/hooks/useSkeleton';
 import {
   passwordValidation,
@@ -17,7 +17,11 @@ type FormValues = {
   confirmPassword: string;
 };
 
-export default function MyInfoPassword() {
+export default function MyInfoPassword({
+  isSkeletonVisible,
+}: {
+  isSkeletonVisible: boolean;
+}) {
   const {
     register,
     handleSubmit,
@@ -30,9 +34,8 @@ export default function MyInfoPassword() {
   });
 
   const { mutate: changePassword } = useChangePassword();
-  const { isPending, isError } = useMyInfo();
 
-  const { showSkeleton, isFadingOut } = useSkeleton(isPending, 1200);
+  const { showSkeleton, isFadingOut } = useSkeleton(isSkeletonVisible, 1200);
 
   const onSubmit = (data: FormValues) => {
     changePassword(data);
@@ -46,7 +49,7 @@ export default function MyInfoPassword() {
   return (
     <ContentSection
       title={
-        showSkeleton || isError ? (
+        showSkeleton ? (
           <SkeletonLine className="h-10 w-full" isFadingOut={isFadingOut} />
         ) : (
           '비밀번호 변경'
@@ -54,7 +57,7 @@ export default function MyInfoPassword() {
       }
     >
       <form onSubmit={handleSubmit(onSubmit)} className="mt-10">
-        {showSkeleton || isError ? (
+        {showSkeleton ? (
           <SkeletonLine
             className="mb-[24px] h-[255px] w-full"
             isFadingOut={isFadingOut}
@@ -99,7 +102,7 @@ export default function MyInfoPassword() {
             />
           </div>
         )}
-        {showSkeleton || isError ? (
+        {showSkeleton ? (
           <SkeletonLine className="h-13 w-full" isFadingOut={isFadingOut} />
         ) : (
           <Button

--- a/src/app/mypage/components/MyInfoPassword.tsx
+++ b/src/app/mypage/components/MyInfoPassword.tsx
@@ -3,12 +3,13 @@ import { useForm } from 'react-hook-form';
 import { ContentSection } from '@/components/common/ContentSection';
 import Input from '@/components/common/Input';
 import Button from '@/components/ui/Buttons';
-import { useChangePassword } from '@/hooks/useMyInfoEdit';
+import SkeletonLine from '@/components/ui/SkeletonLIne';
+import { useChangePassword, useMyInfo } from '@/hooks/useMyInfoEdit';
+import { useSkeleton } from '@/hooks/useSkeleton';
 import {
   passwordValidation,
   confirmPasswordValidation,
 } from '@/lib/validationRules';
-// import { useEffect, useState } from 'react';
 
 type FormValues = {
   password: string;
@@ -28,8 +29,10 @@ export default function MyInfoPassword() {
     reValidateMode: 'onBlur',
   });
 
-  // isLoading, error
   const { mutate: changePassword } = useChangePassword();
+  const { isPending, isError } = useMyInfo();
+
+  const { showSkeleton, isFadingOut } = useSkeleton(isPending, 1200);
 
   const onSubmit = (data: FormValues) => {
     changePassword(data);
@@ -41,54 +44,73 @@ export default function MyInfoPassword() {
   };
 
   return (
-    // 완료되면 인풋 초기화 시켜야함..........!!!
-    <ContentSection title="비밀번호 변경">
+    <ContentSection
+      title={
+        showSkeleton || isError ? (
+          <SkeletonLine className="h-10 w-full" isFadingOut={isFadingOut} />
+        ) : (
+          '비밀번호 변경'
+        )
+      }
+    >
       <form onSubmit={handleSubmit(onSubmit)} className="mt-10">
-        <Input
-          label="현재 비밀번호"
-          type="password"
-          autoComplete="current-password"
-          placeholder="비밀번호 입력"
-          isError={!!errors.password}
-          isSuccess={dirtyFields.password && !errors.password}
-          errorMessage={errors.password?.message}
-          {...register('password', passwordValidation)}
-        />
-        <Input
-          className="my-4"
-          label="새 비밀번호"
-          type="password"
-          autoComplete="new-Password"
-          placeholder="새 비밀번호 입력"
-          isError={!!errors.newPassword}
-          isSuccess={dirtyFields.newPassword && !errors.newPassword}
-          errorMessage={errors.newPassword?.message}
-          {...register('newPassword', passwordValidation)}
-        />
-        <Input
-          className="mb-6"
-          label="새 비밀번호 확인"
-          type="password"
-          autoComplete="new-Password"
-          placeholder="새 비밀번호 입력"
-          isError={!!errors.confirmPassword}
-          isSuccess={dirtyFields.confirmPassword && !errors.confirmPassword}
-          errorMessage={errors.confirmPassword?.message}
-          {...register(
-            'confirmPassword',
-            confirmPasswordValidation(() => ({
-              password: getValues('newPassword'),
-            })),
-          )}
-        />
-        <Button
-          color="violet-white"
-          className="btn-modal-db w-full"
-          type="submit"
-          disabled={!isValid || isSubmitting}
-        >
-          변경
-        </Button>
+        {showSkeleton || isError ? (
+          <SkeletonLine
+            className="mb-[24px] h-[255px] w-full"
+            isFadingOut={isFadingOut}
+          />
+        ) : (
+          <div className="mb-6 h-[255px]">
+            <Input
+              label="현재 비밀번호"
+              type="password"
+              autoComplete="current-password"
+              placeholder="비밀번호 입력"
+              isError={!!errors.password}
+              isSuccess={dirtyFields.password && !errors.password}
+              errorMessage={errors.password?.message}
+              {...register('password', passwordValidation)}
+            />
+            <Input
+              className="my-4"
+              label="새 비밀번호"
+              type="password"
+              autoComplete="new-Password"
+              placeholder="새 비밀번호 입력"
+              isError={!!errors.newPassword}
+              isSuccess={dirtyFields.newPassword && !errors.newPassword}
+              errorMessage={errors.newPassword?.message}
+              {...register('newPassword', passwordValidation)}
+            />
+            <Input
+              label="새 비밀번호 확인"
+              type="password"
+              autoComplete="new-Password"
+              placeholder="새 비밀번호 입력"
+              isError={!!errors.confirmPassword}
+              isSuccess={dirtyFields.confirmPassword && !errors.confirmPassword}
+              errorMessage={errors.confirmPassword?.message}
+              {...register(
+                'confirmPassword',
+                confirmPasswordValidation(() => ({
+                  password: getValues('newPassword'),
+                })),
+              )}
+            />
+          </div>
+        )}
+        {showSkeleton || isError ? (
+          <SkeletonLine className="h-13 w-full" isFadingOut={isFadingOut} />
+        ) : (
+          <Button
+            color="violet-white"
+            className="btn-modal-db w-full"
+            type="submit"
+            disabled={!isValid || isSubmitting}
+          >
+            변경
+          </Button>
+        )}
       </form>
     </ContentSection>
   );

--- a/src/app/mypage/components/MyInfoProfile.tsx
+++ b/src/app/mypage/components/MyInfoProfile.tsx
@@ -5,11 +5,13 @@ import { ContentSection } from '@/components/common/ContentSection';
 import Input from '@/components/common/Input';
 import UploadImageButtonCopy from '@/components/common/UploadImageButton_Mypage';
 import Button from '@/components/ui/Buttons';
+import SkeletonLine from '@/components/ui/SkeletonLIne';
 import {
   useMyInfo,
   useUpdateMyInfo,
   useUploadProfileImage,
 } from '@/hooks/useMyInfoEdit';
+import { useSkeleton } from '@/hooks/useSkeleton';
 import { nicknameValidation } from '@/lib/validationRules';
 
 type FormValues = {
@@ -27,7 +29,7 @@ export default function MyInfoProfile() {
     reValidateMode: 'onBlur',
   });
 
-  const { data } = useMyInfo();
+  const { data, isPending, isError } = useMyInfo();
   const mutation = useUpdateMyInfo();
   const { mutateAsync: uploadImage } = useUploadProfileImage();
 
@@ -66,42 +68,69 @@ export default function MyInfoProfile() {
     });
   };
 
+  const { showSkeleton, isFadingOut } = useSkeleton(isPending, 1200);
+
   return (
-    <ContentSection title="프로필">
+    <ContentSection
+      title={
+        showSkeleton || isError ? (
+          <SkeletonLine className="h-10 w-full" isFadingOut={isFadingOut} />
+        ) : (
+          '프로필'
+        )
+      }
+    >
       <div className="sm:mt-6 sm:grid sm:grid-cols-[auto_1fr] sm:gap-10">
-        <UploadImageButtonCopy
-          className="my-10 size-[100px] sm:my-0 sm:size-[182px]"
-          initialImageUrl={profileImageUrl}
-          onUpload={handleFileSelect}
-          onImageChange={(url) => setProfileImageUrl(url)}
-        />
-        <div>
-          <Input
-            className="input-email mb-4"
-            label="이메일"
-            value={data?.email ?? ''}
-            disabled
-          />
-          <Input
-            className="mb-6"
-            label="닉네임"
-            type="text"
-            autoComplete="nickname"
-            placeholder="닉네임을 적어주세요"
-            isError={!!errors.nickname}
-            isSuccess={dirtyFields.nickname && !errors.nickname}
-            errorMessage={errors.nickname?.message}
-            {...register('nickname', nicknameValidation)}
-          />
-          <Button
-            color="violet-white"
-            className="btn-modal-db w-full"
-            onClick={handleSubmit(handleUpload)}
-            disabled={!isValid || isSubmitting}
-          >
-            저장
-          </Button>
-        </div>
+        {showSkeleton || isError ? (
+          <>
+            <SkeletonLine
+              className="my-10 size-[100px] sm:my-0 sm:size-[182px]"
+              isFadingOut={isFadingOut}
+            />
+            <div className="h-[239px]">
+              <SkeletonLine
+                className="h-full w-full"
+                isFadingOut={isFadingOut}
+              />
+            </div>
+          </>
+        ) : (
+          <>
+            <UploadImageButtonCopy
+              className="my-10 size-[100px] sm:my-0 sm:size-[182px]"
+              initialImageUrl={profileImageUrl}
+              onUpload={handleFileSelect}
+              onImageChange={(url) => setProfileImageUrl(url)}
+            />
+            <div>
+              <Input
+                className="input-email mb-4"
+                label="이메일"
+                value={data?.email ?? ''}
+                disabled
+              />
+              <Input
+                className="mb-6"
+                label="닉네임"
+                type="text"
+                autoComplete="nickname"
+                placeholder="닉네임을 적어주세요"
+                isError={!!errors.nickname}
+                isSuccess={dirtyFields.nickname && !errors.nickname}
+                errorMessage={errors.nickname?.message}
+                {...register('nickname', nicknameValidation)}
+              />
+              <Button
+                color="violet-white"
+                className="btn-modal-db w-full"
+                onClick={handleSubmit(handleUpload)}
+                disabled={!isValid || isSubmitting}
+              >
+                저장
+              </Button>
+            </div>
+          </>
+        )}
       </div>
     </ContentSection>
   );

--- a/src/app/mypage/components/MyInfoProfile.tsx
+++ b/src/app/mypage/components/MyInfoProfile.tsx
@@ -18,7 +18,11 @@ type FormValues = {
   nickname: string;
 };
 
-export default function MyInfoProfile() {
+export default function MyInfoProfile({
+  isSkeletonVisible,
+}: {
+  isSkeletonVisible: boolean;
+}) {
   const {
     register,
     handleSubmit,
@@ -29,7 +33,7 @@ export default function MyInfoProfile() {
     reValidateMode: 'onBlur',
   });
 
-  const { data, isPending, isError } = useMyInfo();
+  const { data } = useMyInfo();
   const mutation = useUpdateMyInfo();
   const { mutateAsync: uploadImage } = useUploadProfileImage();
 
@@ -68,12 +72,12 @@ export default function MyInfoProfile() {
     });
   };
 
-  const { showSkeleton, isFadingOut } = useSkeleton(isPending, 1200);
+  const { showSkeleton, isFadingOut } = useSkeleton(isSkeletonVisible, 1200);
 
   return (
     <ContentSection
       title={
-        showSkeleton || isError ? (
+        showSkeleton ? (
           <SkeletonLine className="h-10 w-full" isFadingOut={isFadingOut} />
         ) : (
           '프로필'
@@ -81,7 +85,7 @@ export default function MyInfoProfile() {
       }
     >
       <div className="sm:mt-6 sm:grid sm:grid-cols-[auto_1fr] sm:gap-10">
-        {showSkeleton || isError ? (
+        {showSkeleton ? (
           <>
             <SkeletonLine
               className="my-10 size-[100px] sm:my-0 sm:size-[182px]"

--- a/src/app/mypage/page.tsx
+++ b/src/app/mypage/page.tsx
@@ -1,14 +1,18 @@
 'use client';
 
 import Image from 'next/image';
-// import Link from 'next/link';
 import { useRouter } from 'next/navigation';
+
+import { useMyInfo } from '@/hooks/useMyInfoEdit';
 
 import MyInfoPassword from './components/MyInfoPassword';
 import MyInfoProfile from './components/MyInfoProfile';
 
 export default function MyPage() {
   const router = useRouter();
+
+  const { isPending, isError } = useMyInfo();
+  const isSkeletonVisible = isPending || isError;
 
   return (
     <div className="min-h-screen bg-[var(--gray-FAFAFA)] p-[20px]">
@@ -29,9 +33,9 @@ export default function MyPage() {
         </button>
       </nav>
       {/* 프로필 */}
-      <MyInfoProfile />
+      <MyInfoProfile isSkeletonVisible={isSkeletonVisible} />
       {/* 비밀번호 변경 */}
-      <MyInfoPassword />
+      <MyInfoPassword isSkeletonVisible={isSkeletonVisible} />
     </div>
   );
 }

--- a/src/components/common/ContentSection.tsx
+++ b/src/components/common/ContentSection.tsx
@@ -1,14 +1,20 @@
 import React from 'react';
 
+type ContentSectionProps = {
+  title: string | React.ReactNode;
+  children: React.ReactNode;
+  className?: string;
+};
+
+type ContentSectionWithActionProps = ContentSectionProps & {
+  titleRight: React.ReactNode;
+};
+
 export function ContentSection({
   title,
   children,
   className = '',
-}: {
-  title: string;
-  children: React.ReactNode;
-  className?: string;
-}) {
+}: ContentSectionProps) {
   return (
     <section
       className={`${className} mb-4 max-w-[none] rounded-[16px] bg-white px-[16px] py-[20px] sm:max-w-[700px] sm:px-[28px] sm:py-[32px]`}
@@ -25,21 +31,16 @@ export function ContentSectionWithAction({
   titleRight,
   children,
   className = '',
-}: {
-  title: string;
-  titleRight: React.ReactNode;
-  children: React.ReactNode;
-  className?: string;
-}) {
+}: ContentSectionWithActionProps) {
   return (
     <section
       className={`${className} mb-4 max-w-[none] rounded-[16px] bg-white py-[20px] sm:max-w-[700px] sm:py-[32px]`}
     >
-      {/* flex items-center justify-between */}
-      <div className="mb-[12px] px-[20px] sm:px-[28px]">
-        <h1 className="text-[20px] font-[700] sm:text-[24px]">{title}</h1>
+      <div className="class-flex class-grid mx-[20px] mb-[12px] sm:mx-[28px]">
+        <h1 className="w-full text-[20px] font-[700] sm:text-[24px]">
+          {title}
+        </h1>
         {titleRight}
-        {/* <div className="flex">{titleRight}</div> */}
       </div>
       {children}
     </section>

--- a/src/components/common/dialog/AlertDialog.tsx
+++ b/src/components/common/dialog/AlertDialog.tsx
@@ -1,3 +1,7 @@
+'use client';
+
+import { useRouter } from 'next/navigation';
+
 import { Button } from '@/components/ui/Button';
 import {
   DialogContent,
@@ -14,19 +18,24 @@ import { useDialogStore } from '@/stores/useDialogStore';
  * @property {string} decription 메세지 본문 텍스트
  * @property {string} closeBtnText 다이얼로그를 닫는 버튼에 표시될 텍스트
  * @property {boolean} isGoBack 닫기 버튼 클릭 후, 이전 다이얼로그로 돌아갈 것인지에 대한 플래그 (기본값 false)
+ * @property {string} navigate useRouter 네비게이션 추가
  */
 interface AlertDialogProps {
   description: string;
   closeBtnText: string;
   isGoBack?: boolean;
+  navigate?: string;
 }
 
 const AlertDialog = ({
   description,
   closeBtnText,
   isGoBack = false,
+  navigate,
 }: AlertDialogProps) => {
   const { closeDialog, goBack } = useDialogStore();
+
+  const router = useRouter();
 
   const content = (
     <DialogContent
@@ -44,7 +53,17 @@ const AlertDialog = ({
       <DialogFooter>
         <Button
           className="bg-taskify-violet-primary hover:bg-taskify-violet h-auto w-full cursor-pointer"
-          onClick={isGoBack ? goBack : closeDialog}
+          // onClick={isGoBack ? goBack : closeDialog}
+          onClick={() => {
+            if (isGoBack) return goBack();
+
+            if (navigate) {
+              router.push(navigate);
+              return closeDialog();
+            }
+
+            return closeDialog();
+          }}
         >
           <span className="text-taskify-md-semibold text-taskify-neutral-0 md:text-taskify-lg-medium">
             {closeBtnText}

--- a/src/hooks/useDashboardMember.ts
+++ b/src/hooks/useDashboardMember.ts
@@ -21,6 +21,7 @@ export const useDashboardMember = (params: MemberQueryParams) => {
     queryFn: () => getDashboardMembers(params),
     enabled: !!dashboardId,
     placeholderData: keepPreviousData,
+    retry: false,
   });
 };
 
@@ -32,6 +33,7 @@ export const useDeleteMember = () => {
 
   return useMutation({
     mutationFn: (memberId: number) => deleteDashboardMembers(memberId),
+    retry: false,
     onSuccess: () => {
       queryClient.invalidateQueries({
         queryKey: ['dashboard-member'],

--- a/src/hooks/useMyInfoEdit.tsx
+++ b/src/hooks/useMyInfoEdit.tsx
@@ -1,7 +1,6 @@
 'use client';
 
 import { useMutation, useQuery, useQueryClient } from '@tanstack/react-query';
-import { useRouter } from 'next/navigation';
 import { useEffect } from 'react';
 
 import AlertDialog from '@/components/common/dialog/AlertDialog';
@@ -21,18 +20,19 @@ export const useUploadProfileImage = () => {
 // 내 정보 가져오기
 export const useMyInfo = () => {
   const { openDialog } = useDialogStore();
-  const router = useRouter();
 
   const query = useQuery({
     queryKey: ['my-info'],
     queryFn: getMyInfo,
     enabled: true,
+    retry: false,
   });
 
   useEffect(() => {
     if (!query.error) return;
 
     const status = getErrorStatus(query.error);
+
     openDialog({
       dialogComponent: (
         <AlertDialog
@@ -42,11 +42,10 @@ export const useMyInfo = () => {
               : '로그인이 만료되었습니다.'
           }
           closeBtnText="확인"
+          navigate="/"
         />
       ),
     });
-
-    router.push('/');
   }, [query.error]);
 
   return query;
@@ -60,6 +59,7 @@ export const useUpdateMyInfo = () => {
 
   return useMutation({
     mutationFn: updateMyInfo,
+    retry: false,
     onSuccess: (upDateData) => {
       queryClient.invalidateQueries({ queryKey: ['my-info'] });
       // 스토리지 업로드
@@ -100,6 +100,7 @@ export const useChangePassword = () => {
       password: string;
       newPassword: string;
     }) => changePassword(password, newPassword),
+    retry: false,
     onSuccess: () => {
       openDialog({
         dialogComponent: (


### PR DESCRIPTION
### 🚨 PR 제목 컨벤션 (필수)

- `feat: 새로운 기능 추가`
- `fix: 버그 수정`
- `docs: 문서 변경`
- `chore: 기타 작업`
- `허용된 타입 목록: feat|fix|docs|style|refactor|perf|test|build|ci|chore|revert`
- Linear Issue Key 를 포함해주세요. 예: `LIN-123/feat: 새로운 기능 추가`

## 🪓 관련 Linear Issue

Linear 이슈 링크: https://linear.app/fe16-intermediate-project/issue/LIN-59/대시보드-수정-마이-페이지-스켈레톤-ui

## 💡 변경 사항 요약
1. 대시보드 수정, 마이 페이지 스켈레톤 UI 적용 
2. 팀 구성원일 때 대시보드 수정 페이지 이동 막음

## 📌 세부 변경 내용
**스켈레톤 UI 적용**
- **대시보드 수정 페이지**
대시보드 유저 정보 로딩, 에러 / 초대 목록 에러 기준로 스켈레톤 UI 적용
- **마이 페이지**
유저 정보 로딩, 에러 기준로 스켈레톤 UI 적용

**AlertDialog.tsx**
- 페이지 이동 라우터(navigate) 프롭 추가
- 페이지 에러 경고 안내가 뜨고, 다이얼로그에 확인을 누르면 페이지 이동 방식으로 변경
_기존 에러 경고가 뜨는 동시에 페이지 이동하였음_
```          
          onClick={() => {
            if (isGoBack) return goBack();

            if (navigate) {
              router.push(navigate);
              return closeDialog();
            }

            return closeDialog();
          }}
```
**대시보드 권한 없이 `dashboardId/edit`로 진입할 경우**
- 팀 구성원이 주소를 통해 `dashboardId/edit` 이동 시 초대 권한이 없다는 안내와 함께 `mydashboad` 페이지로 이동함

### 🧪 테스트 방법 및 결과 (선택 사항)

### 📸 스크린샷 (선택 사항)

### ✍️ 추가 코멘트 (선택 사항)

