### PR TITLE
LIN-31/fix: 이것저것 수정 (Dialog input trim, skeleton ui 관련)

### DIFF
--- a/src/components/common/dialog/ColumnSettingsDialog.tsx
+++ b/src/components/common/dialog/ColumnSettingsDialog.tsx
@@ -58,7 +58,7 @@ const ColumnSettingsDialog = ({
 
   const handleSubmit = (e: FormEvent<HTMLFormElement>) => {
     e.preventDefault();
-    if (!isPending) mutate({ columnId, title: updateColumnValue });
+    if (!isPending) mutate({ columnId, title: updateColumnValue.trim() });
   };
 
   return (
@@ -82,6 +82,7 @@ const ColumnSettingsDialog = ({
             defaultValue={updateColumnValue}
             value={updateColumnValue}
             onChange={handleUpdateChange}
+            maxLength={20}
             isError={errorMessage !== undefined}
             errorMessage={errorMessage}
             inputClassName="text-taskify-neutral-700 text-taskify-md-regular md:text-taskify-lg-regular px-4 py-3"

--- a/src/components/common/dialog/CreateColumnDialog.tsx
+++ b/src/components/common/dialog/CreateColumnDialog.tsx
@@ -47,7 +47,7 @@ const CreateColumnDialog = ({ dashboardId }: CreateColumnDialogProps) => {
 
   const handleSubmit = (e: FormEvent<HTMLFormElement>) => {
     e.preventDefault();
-    if (!isPending) mutate({ title: createColumnValue, dashboardId });
+    if (!isPending) mutate({ title: createColumnValue.trim(), dashboardId });
   };
 
   return (
@@ -73,6 +73,7 @@ const CreateColumnDialog = ({ dashboardId }: CreateColumnDialogProps) => {
             placeholder="컬럼 이름을 입력해주세요."
             value={createColumnValue}
             onChange={handleCreateColumnChange}
+            maxLength={20}
             isError={errorMessage !== undefined}
             errorMessage={errorMessage}
             inputClassName="text-taskify-neutral-700 text-taskify-md-regular md:text-taskify-lg-regular px-4 py-3"

--- a/src/components/common/dialog/CreateDashboardDialog.tsx
+++ b/src/components/common/dialog/CreateDashboardDialog.tsx
@@ -47,7 +47,7 @@ const CreateDashboardDialog = () => {
 
   const handleSubmit = (e: FormEvent<HTMLFormElement>) => {
     e.preventDefault();
-    if (!isPending)
+    if (!isPending && createDashboardValue !== '')
       mutate({ title: createDashboardValue.trim(), color: selectedColor });
   };
 

--- a/src/components/common/dialog/CreateDashboardDialog.tsx
+++ b/src/components/common/dialog/CreateDashboardDialog.tsx
@@ -48,7 +48,7 @@ const CreateDashboardDialog = () => {
   const handleSubmit = (e: FormEvent<HTMLFormElement>) => {
     e.preventDefault();
     if (!isPending)
-      mutate({ title: createDashboardValue, color: selectedColor });
+      mutate({ title: createDashboardValue.trim(), color: selectedColor });
   };
 
   return (
@@ -74,6 +74,7 @@ const CreateDashboardDialog = () => {
             placeholder="대시보드 이름을 입력해주세요."
             value={createDashboardValue}
             onChange={handleCreateDashboardChange}
+            maxLength={20}
             isError={errorMessage !== undefined}
             errorMessage={errorMessage}
             inputClassName="text-taskify-neutral-700 text-taskify-md-regular md:text-taskify-lg-regular px-4 py-3"

--- a/src/components/common/dialog/SendInvitationDialog.tsx
+++ b/src/components/common/dialog/SendInvitationDialog.tsx
@@ -51,7 +51,7 @@ const SendInvitationDialog = ({ dashboardId }: SendInvitationDialogProps) => {
 
   const handleSubmit = (e: FormEvent<HTMLFormElement>) => {
     e.preventDefault();
-    if (!isPending) mutate({ dashboardId, email: emailValue });
+    if (!isPending) mutate({ dashboardId, email: emailValue.trim() });
   };
 
   return (
@@ -78,6 +78,7 @@ const SendInvitationDialog = ({ dashboardId }: SendInvitationDialogProps) => {
             value={emailValue}
             onChange={handleEmailChange}
             isError={errorMessage !== undefined}
+            maxLength={40}
             errorMessage={errorMessage}
             inputClassName="text-taskify-neutral-700 text-taskify-md-regular md:text-taskify-lg-regular px-4 py-3"
           />

--- a/src/components/common/dialog/TaskCardDialog.tsx
+++ b/src/components/common/dialog/TaskCardDialog.tsx
@@ -32,12 +32,12 @@ const TaskCardDialog = ({
   cardId,
   columnName,
 }: TaskCardDialogProps) => {
-  const { data, isLoading } = useQuery({
+  const { data, isPending } = useQuery({
     queryKey: ['detailCard', cardId],
     queryFn: () => getCard(cardId),
   });
 
-  const { showSkeleton, isFadingOut } = useSkeleton(isLoading, 1000);
+  const { showSkeleton, isFadingOut } = useSkeleton(isPending, 1000);
 
   return (
     <DialogContent
@@ -47,24 +47,29 @@ const TaskCardDialog = ({
       {/** Header 영역 */}
       <DialogHeader className="col-start-1 col-end-5 flex gap-0">
         <TaskCardDialogControlArea
-          className="absolute top-5 right-5 flex gap-5"
+          className="absolute top-5 right-5 flex h-8 gap-x-5"
           cardId={cardId}
           cardData={data}
         />
         {showSkeleton ? (
-          <SkeletonLine
-            className="mt-12 h-8 w-4/5 md:mt-0"
-            isFadingOut={isFadingOut}
-          />
+          <>
+            <SkeletonLine
+              className="mt-12 h-8 w-4/5 md:mt-0"
+              isFadingOut={isFadingOut}
+            />
+            <DialogTitle className="hidden" />
+            <DialogDescription className="hidden" />
+          </>
         ) : (
-          <DialogTitle className="mt-12 text-left md:mt-0">
-            <span className="text-taskify-2xl-bold text-taskify-neutral-700">
-              {data?.title}
-            </span>
-          </DialogTitle>
+          <>
+            <DialogTitle className="mt-12 text-left md:mt-0">
+              <span className="text-taskify-2xl-bold text-taskify-neutral-700">
+                {data?.title}
+              </span>
+            </DialogTitle>
+            <DialogDescription className="hidden" />
+          </>
         )}
-        <DialogTitle />
-        <DialogDescription />
       </DialogHeader>
       {/* CardAuthor 영역 */}
       {showSkeleton ? (

--- a/src/components/ui/SkeletonLIne.tsx
+++ b/src/components/ui/SkeletonLIne.tsx
@@ -11,10 +11,14 @@ const SkeletonLine = ({
   isFadingOut = false,
 }: SkeletonLineProps) => (
   <div
-    className={clsx('bg-taskify-neutral-300 animate-pulse rounded', className, {
-      'opacity-0 transition-opacity duration-300': isFadingOut,
-      'animate-pulse': !isFadingOut,
-    })}
+    className={clsx(
+      'bg-taskify-neutral-300 animate-pulse rounded-4xl',
+      className,
+      {
+        'opacity-0 transition-opacity duration-300': isFadingOut,
+        'animate-pulse': !isFadingOut,
+      },
+    )}
   />
 );
 

--- a/src/hooks/useSkeleton.ts
+++ b/src/hooks/useSkeleton.ts
@@ -10,19 +10,26 @@ import { useEffect, useState } from 'react';
 /**
  * @description 데이터 로딩 상태에 따라 스켈레톤 UI의 표시 여부와 페이드 아웃 애니메이션을 관리하는 훅.
  *
- * @param {boolean} isLoading - 현재 데이터 로딩 상태.
+ * @param {boolean} isPending - 현재 데이터 로딩 상태.
  * @param {number} [fadeoutDuration=300] - 스켈레톤이 사라지는 데 걸리는 시간(ms).
  * @returns {UseSkeletonReturn} 스켈레톤 UI 관리에 필요한 상태 값들.
  */
 export const useSkeleton = (
-  isLoading: boolean,
+  isPending: boolean,
   fadeoutDuration: number = 300,
 ) => {
-  const [showSkeleton, setShowSkeleton] = useState(true);
+  const [showSkeleton, setShowSkeleton] = useState(false);
   const [isFadingOut, setIsFadingOut] = useState(false);
 
   useEffect(() => {
-    if (!isLoading && showSkeleton) {
+    if (isPending) {
+      setShowSkeleton(true);
+      setIsFadingOut(false);
+    }
+  }, [isPending]);
+
+  useEffect(() => {
+    if (!isPending && showSkeleton) {
       setIsFadingOut(true);
       const timer = setTimeout(() => {
         setShowSkeleton(false);
@@ -35,14 +42,7 @@ export const useSkeleton = (
         }
       };
     }
-  }, [isLoading, showSkeleton, fadeoutDuration]);
-
-  useEffect(() => {
-    if (isLoading) {
-      setShowSkeleton(true);
-      setIsFadingOut(false);
-    }
-  }, [isLoading]);
+  }, [isPending, showSkeleton, fadeoutDuration]);
 
   return { showSkeleton, isFadingOut };
 };


### PR DESCRIPTION
### 🚨 PR 제목 컨벤션 (필수)

- `feat: 새로운 기능 추가`
- `fix: 버그 수정`
- `docs: 문서 변경`
- `chore: 기타 작업`
- `허용된 타입 목록: feat|fix|docs|style|refactor|perf|test|build|ci|chore|revert`
- Linear Issue Key 를 포함해주세요. 예: `LIN-123/feat: 새로운 기능 추가`

## 🪓 관련 Linear Issue

Linear 이슈 링크: https://linear.app/fe16-intermediate-project/issue/LIN-67/1%EC%B0%A8-%EB%B3%91%ED%95%A9-%ED%9B%84-%EC%88%98%EC%A0%95

## 💡 변경 사항 요약

1차 수정 관련 코드

### 📌 세부 변경 내용

- Dialog input에 20자 제한 및 trim 적용 (이메일은 40자 제한)
- Dialog skeleton 관련 캐싱 데이터는 스켈레톤 미적용 및 border-radius 사이즈 업
- 대시보드 생성에서 input값이 없을 때, submit에 제한
