### PR TITLE
LIN-70/feat: 초대 목록 반응형 구현 및 스켈레톤, 헤더 적용, 유저 아바타 수정

### DIFF
--- a/src/app/dashboard/layout.tsx
+++ b/src/app/dashboard/layout.tsx
@@ -16,9 +16,9 @@ export default function DashboardLayout({
   return (
     <div className="relative flex min-h-screen">
       <Sidebar />
-      <main className="bg-taskify-neutral-100 flex-1 transition-all duration-300 md:ml-[160px] xl:ml-[300px]">
+      <main className="bg-taskify-neutral-100 flex-1 transition-all duration-300">
         <Header />
-        {children}
+        <div className="md:ml-[160px] lg:ml-[300px]">{children}</div>
       </main>
     </div>
   );

--- a/src/app/mydashboard/components/dashboard/DashboardList.tsx
+++ b/src/app/mydashboard/components/dashboard/DashboardList.tsx
@@ -77,8 +77,8 @@ const DashboardList = () => {
 
   return (
     <>
-      <div className="mx-auto w-full max-w-[1000px] px-3 lg:mt-1">
-        <div className="mt-4.5 grid grid-cols-1 gap-2.5 md:grid-cols-2 lg:grid-cols-5">
+      <div className="mx-auto w-full max-w-[1000px] lg:mt-1">
+        <div className="mt-4.5 grid grid-cols-1 justify-items-center gap-2.5 md:grid-cols-2 lg:grid-cols-5">
           <NewDashboardCard />
           {dashboards.map((dashboard) => (
             <DashboardListItem
@@ -89,7 +89,7 @@ const DashboardList = () => {
           ))}
         </div>
       </div>
-      <div className="absolute top-[495px] left-[220px] flex justify-center md:top-[395px] md:left-[630px] lg:top-[370px] lg:left-[1190px]">
+      <div className="absolute top-[645px] left-1/2 flex -translate-x-1/2 transform justify-center md:top-[408px] md:left-[660px] md:translate-x-0 md:transform-none lg:top-[370px] lg:left-[1190px]">
         <PaginationButton
           page={page}
           size={itemsPerPage}

--- a/src/app/mydashboard/components/dashboard/DashboardSection.tsx
+++ b/src/app/mydashboard/components/dashboard/DashboardSection.tsx
@@ -3,7 +3,7 @@
 import { useQuery } from '@tanstack/react-query';
 
 import CreateDashboardDialog from '@/components/common/dialog/CreateDashboardDialog';
-import { Skeleton } from '@/components/ui/skeleton';
+import SkeletonLine from '@/components/ui/SkeletonLIne';
 import { getDashboards } from '@/lib/api/dashboardService';
 import { useDialogStore } from '@/stores/useDialogStore';
 
@@ -25,14 +25,53 @@ const DashboardSection = () => {
 
   const { openDialog } = useDialogStore();
 
-  if (isPending) return <Skeleton />;
+  if (isPending) {
+    return (
+      <div className="bg-taskify-neutral-0 mb-10 flex h-[550px] w-[330px] flex-col rounded-2xl p-6 px-[15px] md:mt-3 md:h-[360px] md:w-[620px] lg:mt-5 lg:h-[330px] lg:w-[1022px]">
+        {/* 1. h1 대시보드 제목 스켈레톤 */}
+        <SkeletonLine
+          className="mb-6 h-8 w-32 md:ml-4 lg:ml-4"
+          isFadingOut={false}
+        />
+
+        {/* 대시보드 카드들 */}
+        <div className="mx-auto w-full max-w-[1000px] lg:mt-1">
+          <div className="mt-4.5 grid grid-cols-1 justify-items-center gap-2.5 md:grid-cols-2 lg:grid-cols-5">
+            {/* 대시보드 카드들 - 타이틀과 멤버카운트만 스켈레톤 */}
+            {['skeleton-1', 'skeleton-2', 'skeleton-3', 'skeleton-4'].map(
+              (id) => (
+                <div
+                  key={id}
+                  className="flex min-h-[58px] w-[290px] flex-col items-start justify-between gap-2 rounded-lg border p-4 md:min-h-[68px] md:w-[275px] md:flex-row lg:min-h-[175px] lg:w-[175px] lg:flex-col"
+                >
+                  {/* 2. 대시보드 카드 타이틀 스켈레톤 */}
+                  <div className="flex items-center gap-2 md:flex-1 lg:w-full">
+                    <SkeletonLine
+                      className="h-5 w-32 md:w-24 lg:w-28"
+                      isFadingOut={false}
+                    />
+                  </div>
+
+                  {/* 3. 멤버 카운트 문구 스켈레톤 */}
+                  <div className="hidden lg:mb-2 lg:block">
+                    <SkeletonLine className="h-4 w-16" isFadingOut={false} />
+                  </div>
+                </div>
+              ),
+            )}
+          </div>
+        </div>
+      </div>
+    );
+  }
+
   if (isError) return <div>에러 발생: {error.message}</div>;
 
   const hasDashboards = (data?.dashboards?.length ?? 0) > 0;
 
   // 기존 대시보드 목록이 없을 시 새로운 대시보드 만들 수 있는 버튼 출력
   return (
-    <div className="bg-taskify-neutral-0 mb-10 flex h-[550px] w-[340px] flex-col rounded-2xl p-6 px-[15px] md:mt-3 md:h-[360px] md:w-[620px] lg:mt-5 lg:h-[330px] lg:w-[1022px]">
+    <div className="bg-taskify-neutral-0 mb-10 flex h-[550px] w-[330px] flex-col rounded-2xl p-6 px-[15px] md:mt-3 md:h-[360px] md:w-[620px] lg:mt-5 lg:h-[330px] lg:w-[1022px]">
       <h1 className="text-taskify-2xl-bold text-taskify-neutral-700 md:ml-4 lg:ml-4">
         대시보드
       </h1>

--- a/src/app/mydashboard/components/dashboard/MemberAvatars.tsx
+++ b/src/app/mydashboard/components/dashboard/MemberAvatars.tsx
@@ -29,7 +29,7 @@ const MemberAvatars = ({
         </div>
       ))}
       {rest > 0 && (
-        <div className="bg-muted text-muted-foreground z-10 -ml-2 flex size-[26px] items-center justify-center rounded-full border border-white text-xs font-medium">
+        <div className="bg-muted text-muted-foreground z-10 -ml-2 flex size-[34px] items-center justify-center rounded-full border border-white text-xs font-medium">
           +{rest}
         </div>
       )}

--- a/src/app/mydashboard/components/invitation/InvitationDashboard.tsx
+++ b/src/app/mydashboard/components/invitation/InvitationDashboard.tsx
@@ -2,7 +2,7 @@
 
 import { useState } from 'react';
 
-import { Skeleton } from '@/components/ui/skeleton';
+import SkeletonLine from '@/components/ui/SkeletonLIne';
 import { useDebounce } from '@/hooks/useDebounce';
 import { useGetInvitations } from '@/hooks/useGetInvitations';
 
@@ -18,13 +18,54 @@ const InvitationDashboard = () => {
   // 디바운스 시간은 300ms로 사용
   const debouncedSearchTerm = useDebounce(searchTerm, 300);
 
-  // 로딩중 UI 추가 (없는 경우 빈 목록이 먼저 노출되는 문제 발생) - 추가했으나 깜빡임처럼 보이는 점 문제.
+  // 로딩중 UI 추가
   if (isPending) {
-    return <Skeleton className="h-[450px] w-[1022px] rounded-2xl" />;
+    return (
+      <div className="bg-taskify-neutral-0 flex h-[550px] w-[330px] flex-col rounded-2xl p-6 md:h-[450px] md:w-[620px] lg:h-[450px] lg:w-[1022px] lg:px-[32px]">
+        {/* h1 초대받은 대시보드 제목 스켈레톤 */}
+        <SkeletonLine className="mb-5 h-8 w-40" isFadingOut={false} />
+
+        {/* 검색 InputBox 스켈레톤 */}
+        <SkeletonLine
+          className="mb-4 h-10 w-full rounded-md"
+          isFadingOut={false}
+        />
+
+        {/* 테이블 행들 - td만 */}
+        <div className="px-4">
+          {[
+            'skeleton-1',
+            'skeleton-2',
+            'skeleton-3',
+            'skeleton-4',
+            'skeleton-5',
+          ].map((id) => (
+            <div
+              key={id}
+              className="border-taskify-neutral-200 flex items-center border-b py-3"
+            >
+              <div className="mr-4 md:w-2/4 lg:w-3/6">
+                <div className="h-5 w-3/4 rounded bg-gray-100" />
+              </div>
+              <div className="mr-4 md:w-1/4 lg:w-1/6">
+                <div className="h-5 rounded bg-gray-100" />
+              </div>
+              <div className="mr-4 hidden lg:block lg:w-1/6">
+                <div className="h-5 rounded bg-gray-100" />
+              </div>
+              <div className="flex gap-2 md:w-1/4 lg:w-1/6">
+                <div className="h-8 w-16 rounded bg-gray-100" />
+                <div className="h-8 w-16 rounded bg-gray-100" />
+              </div>
+            </div>
+          ))}
+        </div>
+      </div>
+    );
   }
 
   return (
-    <div className="bg-taskify-neutral-0 flex h-[550px] w-[340px] flex-col rounded-2xl p-6 md:h-[450px] md:w-[620px] lg:h-[450px] lg:w-[1022px] lg:px-[32px]">
+    <div className="bg-taskify-neutral-0 flex h-[550px] w-[330px] flex-col rounded-2xl p-6 md:h-[450px] md:w-[620px] lg:h-[450px] lg:w-[1022px] lg:px-[32px]">
       <h1 className="text-taskify-2xl-bold text-taskify-neutral-700">
         초대받은 대시보드
       </h1>

--- a/src/app/mydashboard/components/invitation/InvitationList.tsx
+++ b/src/app/mydashboard/components/invitation/InvitationList.tsx
@@ -75,57 +75,59 @@ const InvitationList = ({ searchTerm }: InvitationProps) => {
       />
     ))
   ) : (
-    <table className="w-full text-left">
-      <thead className="bg-taskify-neutral-0 sticky top-0 z-10">
-        <tr>
-          <th
-            colSpan={4}
-            aria-hidden="true"
-            className="bg-taskify-neutral-0 sticky h-6 border-none"
-          >
-            &nbsp;
-          </th>
-        </tr>
-        <tr>
-          <th className="text-taskify-lg-regular text-taskify-neutral-400 md:pl-[50px] lg:pl-[76px]">
-            이름
-          </th>
-          <th className="text-taskify-lg-regular text-taskify-neutral-400">
-            초대자
-          </th>
-          <th className="text-taskify-lg-regular text-taskify-neutral-400 hidden lg:table-cell">
-            초대한 시점
-          </th>
-          <th className="text-taskify-lg-regular text-taskify-neutral-400 pl-[65px]">
-            수락 여부
-          </th>
-        </tr>
-      </thead>
-      <tbody>
-        {allInvitations.map((invitation, i) => {
-          const isLast = i === allInvitations.length - 1;
-          return (
-            <InvitationListItem
-              key={invitation.id}
-              invitation={invitation}
-              searchTerm={searchTerm}
-              observerRef={isLast ? observerEl : null}
-            />
-          );
-        })}
-        <tr ref={observerEl}>
-          <td colSpan={4} aria-hidden="true">
-            <div style={{ height: '10px' }} />
-          </td>
-        </tr>
-
-        {isFetching && (
+    <div className="px-4">
+      <table className="w-full table-fixed text-left">
+        <thead className="bg-taskify-neutral-0 sticky top-0 z-10">
           <tr>
-            <td colSpan={4}>로딩 중...</td>
+            <th
+              colSpan={4}
+              aria-hidden="true"
+              className="bg-taskify-neutral-0 sticky h-6 border-none"
+            >
+              &nbsp;
+            </th>
           </tr>
-        )}
-      </tbody>
-    </table>
+          <tr>
+            <th className="text-taskify-lg-regular text-taskify-neutral-400 md:w-2/4 lg:w-3/6">
+              이름
+            </th>
+            <th className="text-taskify-lg-regular text-taskify-neutral-400 md:w-1/4 lg:w-1/6">
+              초대자
+            </th>
+            <th className="text-taskify-lg-regular text-taskify-neutral-400 hidden lg:table-cell lg:w-1/6">
+              초대한 시점
+            </th>
+            <th className="text-taskify-lg-regular text-taskify-neutral-400 md:w-1/4 lg:w-1/6">
+              수락 여부
+            </th>
+          </tr>
+        </thead>
+        <tbody>
+          {allInvitations.map((invitation, i) => {
+            const isLast = i === allInvitations.length - 1;
+            return (
+              <InvitationListItem
+                key={invitation.id}
+                invitation={invitation}
+                searchTerm={searchTerm}
+                observerRef={isLast ? observerEl : null}
+              />
+            );
+          })}
+          <tr ref={observerEl}>
+            <td colSpan={4} aria-hidden="true">
+              <div style={{ height: '10px' }} />
+            </td>
+          </tr>
+
+          {isFetching && (
+            <tr>
+              <td colSpan={4}>로딩 중...</td>
+            </tr>
+          )}
+        </tbody>
+      </table>
+    </div>
   );
 };
 

--- a/src/app/mydashboard/components/invitation/InvitationListItem.tsx
+++ b/src/app/mydashboard/components/invitation/InvitationListItem.tsx
@@ -54,21 +54,21 @@ const InvitationListItem = ({
           isRemoving ? 'opacity-0' : 'opacity-100'
         }`}
       >
-        <td className="text-taskify-lg-regular text-taskify-neutral-700 truncate pr-5 md:max-w-[160px] md:pl-[50px] lg:pl-[76px]">
+        <td className="text-taskify-lg-regular text-taskify-neutral-700 truncate md:w-2/4 lg:w-3/6">
           {highlightText(dashboard.title, searchTerm)}
         </td>
-        <td className="text-taskify-lg-regular text-taskify-neutral-700">
+        <td className="text-taskify-lg-regular text-taskify-neutral-700 md:w-1/4 lg:w-1/6">
           {inviter.nickname}
         </td>
-        <td className="text-taskify-lg-regular text-taskify-neutral-700 hidden lg:table-cell">
+        <td className="text-taskify-lg-regular text-taskify-neutral-700 hidden lg:table-cell lg:w-1/6">
           {timeAgo}
         </td>
-        <td className="py-1">
-          <div className="flex md:ml-4 md:gap-0 lg:gap-2.5">
+        <td className="py-2 md:w-1/4 lg:w-1/6">
+          <div className="flex gap-2">
             <Button
               type="button"
               color="violet-white"
-              className="text-taskify-md-medium m-1.5 md:px-[23px] md:py-[6px] lg:px-[29px] lg:py-[7px]"
+              className="text-taskify-md-medium mt-1.5 px-8 py-2 whitespace-nowrap"
               onClick={() => {
                 setIsRemoving(true);
                 setTimeout(() => {
@@ -92,7 +92,7 @@ const InvitationListItem = ({
             <Button
               type="button"
               color="white-violet"
-              className="border-taskify-neutral-300 text-taskify-md-medium m-1.5 border-[1px] md:px-[23px] md:py-[6px] lg:px-[29px] lg:py-[7px]"
+              className="border-taskify-neutral-300 text-taskify-md-medium mt-1.5 border-[1px] px-8 py-2 whitespace-nowrap"
               onClick={() => {
                 setIsRemoving(true);
                 setTimeout(() => {

--- a/src/app/mydashboard/components/invitation/Noresult.tsx
+++ b/src/app/mydashboard/components/invitation/Noresult.tsx
@@ -3,7 +3,7 @@ import { MdOutlineSearchOff } from 'react-icons/md';
 const NoResult = () => {
   return (
     <div className="relative">
-      <div className="bg-taskify-neutral-200 absolute top-9.5 left-4.5 flex h-55 w-64 items-center justify-center rounded-2xl md:h-63 md:w-132 lg:h-63 lg:w-230">
+      <div className="bg-taskify-neutral-0 absolute top-5 left-4.5 flex h-55 w-64 items-center justify-center rounded-2xl md:h-63 md:w-132 lg:h-63 lg:w-230">
         <div className="flex-col justify-items-center">
           <MdOutlineSearchOff className="text-taskify-neutral-500 h-15 w-15" />
           <p className="text-taskify-lg-regular text-taskify-neutral-500">

--- a/src/app/mydashboard/components/invitation/Noresult.tsx
+++ b/src/app/mydashboard/components/invitation/Noresult.tsx
@@ -3,7 +3,7 @@ import { MdOutlineSearchOff } from 'react-icons/md';
 const NoResult = () => {
   return (
     <div className="relative">
-      <div className="bg-taskify-neutral-0 absolute top-5 left-4.5 flex h-55 w-64 items-center justify-center rounded-2xl md:h-63 md:w-132 lg:h-63 lg:w-230">
+      <div className="bg-taskify-neutral-0 absolute top-20 left-4.5 flex h-55 w-64 items-center justify-center rounded-2xl md:top-5 md:h-63 md:w-132 lg:h-63 lg:w-230">
         <div className="flex-col justify-items-center">
           <MdOutlineSearchOff className="text-taskify-neutral-500 h-15 w-15" />
           <p className="text-taskify-lg-regular text-taskify-neutral-500">

--- a/src/app/mydashboard/components/invitation/SearchInput.tsx
+++ b/src/app/mydashboard/components/invitation/SearchInput.tsx
@@ -18,7 +18,7 @@ const SearchInput = ({ val, onChange }: SearchInputProps) => {
         placeholder="초대받은 프로젝트 이름을 검색하세요"
         value={val}
         onChange={handleChange}
-        className="text-taskify-md-regular md:text-taskify-lg-regular text-taskify-neutral-400 border-taskify-neutral-300 h-[40px] w-[290px] rounded-md border-[1px] py-1.5 pl-10 md:w-[570px] lg:w-[954px]"
+        className="text-taskify-md-regular md:text-taskify-lg-regular text-taskify-neutral-400 border-taskify-neutral-300 h-[40px] w-full rounded-md border-[1px] py-1.5 pl-10"
       />
       <IoSearchSharp className="text-taskify-neutral-700 absolute top-2.5 left-3 h-5.5 w-5.5" />
     </div>

--- a/src/app/mydashboard/layout.tsx
+++ b/src/app/mydashboard/layout.tsx
@@ -18,7 +18,7 @@ export default function DashboardLayout({
     <div className="relative flex min-h-screen">
       <Sidebar />
       <Header />
-      <main className="flex-1 md:ml-[160px] xl:ml-[300px]">{children}</main>
+      <main className="flex-1 md:ml-[160px] lg:ml-[300px]">{children}</main>
     </div>
   );
 }

--- a/src/app/mydashboard/page.tsx
+++ b/src/app/mydashboard/page.tsx
@@ -4,7 +4,7 @@ import InvitationDashboard from './components/invitation/InvitationDashboard';
 const Mydashboard = () => {
   return (
     <div className="bg-taskify-neutral-200 min-h-screen">
-      <div className="ml-6 h-screen flex-col md:ml-3.5 md:block md:h-auto md:pt-20 lg:ml-10 lg:pt-20">
+      <div className="mx-auto flex max-w-[330px] flex-col gap-1 pt-[150px] pb-6 md:ml-10 md:block md:h-auto md:gap-6 md:pt-22 lg:ml-10 lg:pt-20">
         <DashboardSection />
         <InvitationDashboard />
       </div>

--- a/src/app/mypage/layout.tsx
+++ b/src/app/mypage/layout.tsx
@@ -18,7 +18,7 @@ export default function MypageLayout({
     <div className="relative flex min-h-screen">
       <Sidebar />
       <Header />
-      <main className="flex-1 md:mt-[90px] md:ml-[160px] xl:ml-[300px]">
+      <main className="flex-1 md:mt-[60px] md:ml-[160px] lg:ml-[300px]">
         {children}
       </main>
     </div>

--- a/src/components/common/Profile.tsx
+++ b/src/components/common/Profile.tsx
@@ -41,7 +41,7 @@ export function AvatarProfile({
   const { container, textSize } = ChipSizeMap[size];
   const { bgClass } = getTextBasedColorClasses(userName, 'profile');
   return (
-    <Avatar className={`${container} profile-avatar`}>
+    <Avatar className={`${container} profile-avatar cursor-pointer`}>
       <AvatarImage src={profileImg ?? undefined} />
       <AvatarFallback className={`${bgClass} ${textSize}`}>
         {userName.toUpperCase().slice(0, 1)}

--- a/src/components/common/header/Header.tsx
+++ b/src/components/common/header/Header.tsx
@@ -64,31 +64,6 @@ const Header = () => {
     }
   }, [userQuery.data]);
 
-  // 2 액세스 토큰
-
-  // const accessToken =
-  //   typeof window !== 'undefined' ? localStorage.getItem('accessToken') : null;
-
-  // useQuery({
-  //   queryKey: ['my-info'],
-  //   queryFn: getMyInfo,
-  //   enabled: !!accessToken,
-  //   select: (data) => {
-  //     useAuthStore.getState().setUser(data);
-  //     return data;
-  //   },
-  // });
-
-  // 1 로그인 문제
-  // useQuery({
-  //   queryKey: ['my-info'],
-  //   queryFn: getMyInfo,
-  //   select: (data) => {
-  //     useAuthStore.getState().setUser(data);
-  //     return data;
-  //   },
-  // });
-
   useQuery<{ members: Member[] }>({
     queryKey: ['dashboard-members', dashboardId],
     queryFn: () => getDashboardMembers({ dashboardId }),

--- a/src/components/common/header/Header.tsx
+++ b/src/components/common/header/Header.tsx
@@ -7,6 +7,7 @@ import { usePathname } from 'next/navigation';
 import { useEffect } from 'react';
 
 import MemberAvatars from '@/app/mydashboard/components/dashboard/MemberAvatars';
+import useIsMobile from '@/hooks/useIsMobile';
 import { getMyInfo } from '@/lib/api/auth';
 import { getDashboardMembers } from '@/lib/api/dashboardMemberService';
 import { getDashboardById } from '@/lib/api/dashboardService';
@@ -84,6 +85,8 @@ const Header = () => {
     },
   });
 
+  const isMobile = useIsMobile();
+
   return (
     <header className="border-b-taskify-neutral-300 bg-taskify-neutral-0 fixed z-10 flex h-[60px] w-full items-center justify-between border-[1px]">
       <div className="flex h-full w-full items-center justify-between px-4 md:ml-[160px] md:px-7 lg:ml-[300px]">
@@ -110,7 +113,7 @@ const Header = () => {
           {/* 관리와 초대하기 버튼은 대시보드 생성자만 볼 수 있음 */}
           {config.showManageButton && isOwner && <ManageButton />}
           {config.showInviteButton && isOwner && <InviteButton />}
-          {config.showMemberAvatars && (
+          {config.showMemberAvatars && !isMobile && (
             <MemberAvatars members={members} type="header" />
           )}
           {/* 구분선 */}

--- a/src/components/common/header/Header.tsx
+++ b/src/components/common/header/Header.tsx
@@ -111,8 +111,7 @@ const Header = () => {
 
   return (
     <header className="border-b-taskify-neutral-300 bg-taskify-neutral-0 fixed z-10 flex h-[60px] w-full items-center justify-between border-[1px]">
-      {/* xl로 우선 지정 -> lg로 논의 후 조건 수정해야함. */}
-      <div className="flex h-full w-full items-center justify-between px-4 md:ml-[160px] md:px-7 xl:ml-[300px]">
+      <div className="flex h-full w-full items-center justify-between px-4 md:ml-[160px] md:px-7 lg:ml-[300px]">
         <div className="flex gap-2">
           {/* 모바일에서만 로고 보이기 */}
           <div className="md:hidden">

--- a/src/components/common/header/UserAvatar.tsx
+++ b/src/components/common/header/UserAvatar.tsx
@@ -1,12 +1,6 @@
 import { useRouter } from 'next/navigation';
-import { useEffect, useState } from 'react';
+import { useEffect, useRef, useState } from 'react';
 
-import {
-  DropdownMenu,
-  DropdownMenuTrigger,
-  DropdownMenuContent,
-  DropdownMenuItem,
-} from '@/components/ui/DropdownMenu';
 import { useAuth } from '@/hooks/useAuth';
 import { useAuthStore } from '@/stores/useAuthStore';
 
@@ -34,49 +28,91 @@ const UserAvatar = () => {
   const user = useAuthStore((state) => state.user);
   const { logout } = useAuth();
   const router = useRouter();
+  const [isOpen, setIsOpen] = useState(false);
+  const dropdownRef = useRef<HTMLDivElement>(null);
 
-  const nicknameLength = user?.nickname.length;
+  const nicknameLength = user?.nickname.length ?? 0;
   const baseWidth = 100; // 최소 100px
   const perCharWidth = 8; // 글자당 8px 추가
   const menuWidth = Math.min(250, baseWidth + nicknameLength * perCharWidth);
 
+  // 외부 클릭 시 드롭다운 닫기
+  useEffect(() => {
+    const handleClickOutside = (event: MouseEvent) => {
+      if (
+        dropdownRef.current &&
+        !dropdownRef.current.contains(event.target as Node)
+      ) {
+        setIsOpen(false);
+      }
+    };
+
+    if (isOpen) {
+      document.addEventListener('mousedown', handleClickOutside);
+    }
+
+    return () => {
+      document.removeEventListener('mousedown', handleClickOutside);
+    };
+  }, [isOpen]);
+
   // 임시로 값이 없을 시 처리
   if (!user) return null;
 
+  const handleMyPageClick = () => {
+    setIsOpen(false);
+    router.push('/mypage');
+  };
+
+  const handleDashboardClick = () => {
+    setIsOpen(false);
+    router.push('/mydashboard');
+  };
+
+  const handleLogoutClick = () => {
+    setIsOpen(false);
+    logout();
+    router.push('/');
+  };
+
+  const menuItems = [
+    { id: 'mypage', label: '내 정보', onClick: handleMyPageClick },
+    { id: 'mydashboard', label: '내 대시보드', onClick: handleDashboardClick },
+    { id: 'logout', label: '로그아웃', onClick: handleLogoutClick },
+  ];
+
   return (
-    <DropdownMenu>
-      <DropdownMenuTrigger asChild>
-        <button type="button">
-          <UserProfile
-            userName={user.nickname}
-            profileImg={user.profileImageUrl}
-            size={isMobile ? 'md' : 'lg'}
-          />
-        </button>
-      </DropdownMenuTrigger>
-      <DropdownMenuContent
-        align="start"
-        sideOffset={10}
-        className="z-50"
-        style={{ width: `${menuWidth}px` }}
-        forceMount
+    <div className="relative" ref={dropdownRef}>
+      <button
+        type="button"
+        onClick={() => setIsOpen(!isOpen)}
+        className="focus:outline-none"
       >
-        <DropdownMenuItem onClick={() => router.push('/mypage')}>
-          내 정보
-        </DropdownMenuItem>
-        <DropdownMenuItem onClick={() => router.push('/mydashboard')}>
-          내 대시보드
-        </DropdownMenuItem>
-        <DropdownMenuItem
-          onClick={() => {
-            logout();
-            router.push('/');
-          }}
+        <UserProfile
+          userName={user.nickname}
+          profileImg={user.profileImageUrl}
+          size={isMobile ? 'md' : 'lg'}
+        />
+      </button>
+
+      {isOpen && (
+        <div
+          className="absolute top-full left-0 z-[9999] mt-2.5 rounded-md border border-gray-200 bg-white shadow-md"
+          style={{ width: `${menuWidth}px` }}
         >
-          로그아웃
-        </DropdownMenuItem>
-      </DropdownMenuContent>
-    </DropdownMenu>
+          {menuItems.map((item) => (
+            <button
+              key={item.id}
+              type="button"
+              className="text-taskify-lg-regular text-taskify-neutral-500 w-full px-3 py-2 text-left first:rounded-t-md last:rounded-b-md hover:bg-gray-50 focus:bg-gray-50 focus:outline-none"
+              onClick={item.onClick}
+            >
+              {item.label}
+            </button>
+          ))}
+        </div>
+      )}
+    </div>
   );
 };
 

--- a/src/components/common/header/UserAvatar.tsx
+++ b/src/components/common/header/UserAvatar.tsx
@@ -35,6 +35,11 @@ const UserAvatar = () => {
   const { logout } = useAuth();
   const router = useRouter();
 
+  const nicknameLength = user?.nickname.length;
+  const baseWidth = 100; // 최소 100px
+  const perCharWidth = 8; // 글자당 8px 추가
+  const menuWidth = Math.min(250, baseWidth + nicknameLength * perCharWidth);
+
   // 임시로 값이 없을 시 처리
   if (!user) return null;
 
@@ -50,9 +55,10 @@ const UserAvatar = () => {
         </button>
       </DropdownMenuTrigger>
       <DropdownMenuContent
-        align="end"
-        sideOffset={8}
+        align="start"
+        sideOffset={10}
         className="z-50"
+        style={{ width: `${menuWidth}px` }}
         forceMount
       >
         <DropdownMenuItem onClick={() => router.push('/mypage')}>

--- a/src/hooks/useIsMobile.ts
+++ b/src/hooks/useIsMobile.ts
@@ -1,0 +1,20 @@
+import { useEffect, useState } from 'react';
+
+const useIsMobile = () => {
+  const [isMobile, setIsMobile] = useState(false);
+
+  useEffect(() => {
+    const checkMobile = () => {
+      setIsMobile(window.innerWidth < 768); // Tailwind 기준 md
+    };
+
+    checkMobile(); // 초기 실행
+    window.addEventListener('resize', checkMobile);
+
+    return () => window.removeEventListener('resize', checkMobile);
+  }, []);
+
+  return isMobile;
+};
+
+export default useIsMobile;


### PR DESCRIPTION
### 🚨 PR 제목 컨벤션 (필수)

- `feat: 새로운 기능 추가`
- `fix: 버그 수정`
- `docs: 문서 변경`
- `chore: 기타 작업`
- `허용된 타입 목록: feat|fix|docs|style|refactor|perf|test|build|ci|chore|revert`
- Linear Issue Key 를 포함해주세요. 예: `LIN-123/feat: 새로운 기능 추가`

## 🪓 관련 Linear Issue

Linear 이슈 링크: https://linear.app/fe16-intermediate-project/issue/LIN-70/반응형-수정

## 💡 변경 사항 요약

초대목록 반응형 구현하였습니다.
mydashboard 내 스켈레톤을 적용하였습니다.
각 페이지에 헤더 적용 및 마진 조절하였습니다.
유저 아바타 드롭다운 컴포넌트를 기존 컴포넌트에서 커스텀 드롭다운으로 변경하였습니다.

### 📌 세부 변경 내용

-

### 🧪 테스트 방법 및 결과 (선택 사항)

1.
2.

### 📸 스크린샷 (선택 사항)

### ✍️ 추가 코멘트 (선택 사항)

- 기존 드롭다운 컴포넌트의 경우 어떻게 해도 DOM 때문에 다른 요소들이 움직이는 걸 해결할 수가 없었습니다. 그래서 커스텀 드롭다운을 만들어 대체하였습니다. 이후 랜딩 페이지에서 글자색이 보이지 않는 이슈도 해결하였습니다.
- 초대목록 내 테이블 간격도 수정하였습니다. 하지만 테이블이다보니 간격 조절에 제약이 많습니다.
- 초대목록 내 테이블 간격을 고정하여 검색 결과 산출시에도 움직이지 않게 수정하였습니다.
- 모바일 사이즈에서 대시보드 리스트 내 페이지네이션 위치 고민 중.
