### PR TITLE
LIN-76/refactor: 태그 칩 스타일 수정, 글자 수 길어지면 붉은 색 나오는 이슈 해결

### DIFF
--- a/src/components/common/Chips.tsx
+++ b/src/components/common/Chips.tsx
@@ -136,7 +136,9 @@ export function TagChip({ size, children }: ContentChipProps) {
       };
   const { bgClass, textClass } = getTextBasedColorClasses(trimmed, 'chip');
   return (
-    <span className={`${bgClass} ${textClass} ${tagContainer} chip-tag`}>
+    <span
+      className={`${bgClass} ${textClass} ${tagContainer} chip-tag shrink-0`}
+    >
       {trimmed}
     </span>
   );

--- a/src/components/common/Profile.tsx
+++ b/src/components/common/Profile.tsx
@@ -44,7 +44,7 @@ export function AvatarProfile({
     ? ChipSizeMap[size]
     : {
         container: 'size-[34px] transition-all md:size-[38px]',
-        textSize: 'text-base',
+        textSize: 'text-12px md:text-base',
       };
   const { bgClass } = getTextBasedColorClasses(userName, 'profile');
   return (

--- a/src/lib/utils/colorUtils.ts
+++ b/src/lib/utils/colorUtils.ts
@@ -11,25 +11,37 @@ interface ColorClasses {
   textClass?: string;
 }
 
+const calculateColorIndex = (hash: number, arrayLength: number): number => {
+  return hash % arrayLength;
+};
+
 // 일정한 규칙을 통해 받은 텍스트로 랜덤 색상을 보여줌
 export const getTextBasedColorClasses = (
   text: string,
   mode: Mode = 'profile',
 ): ColorClasses => {
   let hash = 0;
+  const MODULO_CONSTANT = 1000000007; // 해시 값을 제한할 큰 소수 상수
+
   // 문자열을 유니코드로 변환
   for (let i = 0; i < text.length; i += 1) {
-    hash = text.charCodeAt(i) + hash * 31;
+    hash = (text.charCodeAt(i) + hash * 31) % MODULO_CONSTANT;
+    if (hash < 0) {
+      hash += MODULO_CONSTANT;
+    }
   }
 
   // profile의 경우
-  const indexProfile = Math.abs(hash) % allBackgroundClassesProfile.length;
   if (mode === 'profile') {
+    const indexProfile = calculateColorIndex(
+      hash,
+      allBackgroundClassesProfile.length,
+    );
     return { bgClass: allBackgroundClassesProfile[indexProfile] };
   }
 
   // chip의 경우
-  const indexChip = Math.abs(hash) % allBackgroundClassesChip.length;
+  const indexChip = calculateColorIndex(hash, allBackgroundClassesChip.length);
   return {
     bgClass: allBackgroundClassesChip[indexChip],
     textClass: allTextClassesChip[indexChip],


### PR DESCRIPTION
### 🚨 PR 제목 컨벤션 (필수)

- `feat: 새로운 기능 추가`
- `fix: 버그 수정`
- `docs: 문서 변경`
- `chore: 기타 작업`
- `허용된 타입 목록: feat|fix|docs|style|refactor|perf|test|build|ci|chore|revert`
- Linear Issue Key 를 포함해주세요. 예: `LIN-123/feat: 새로운 기능 추가`

## 🪓 관련 Linear Issue

Linear 이슈 링크: https://linear.app/fe16-intermediate-project/issue/LIN-76/태그-칩-스타일-수정-글자-수-길어지면-붉은-색-나오는-이슈-해결

## 💡 변경 사항 요약

### 📌 세부 변경 내용
- 태그 칩 스타일 깨짐 수정 / flex-shrink
- 글자 수가 길어지면 붉은 색상만 나오는 거 해결했습니다.

### 🧪 테스트 방법 및 결과 (선택 사항)

### 📸 스크린샷 (선택 사항)

### ✍️ 추가 코멘트 (선택 사항)

-
