### PR TITLE
LIN-78/feat: 마이페이지 이미지 업로드 SVG 막음, 초대목록 네비게이션, 프로필 아바타 border style

### DIFF
--- a/src/app/dashboard/[dashboardId]/edit/components/DashboardInvitations.tsx
+++ b/src/app/dashboard/[dashboardId]/edit/components/DashboardInvitations.tsx
@@ -55,13 +55,17 @@ export default function DashboardInvitations({
           <SkeletonLine className="h-10 w-[135px]" isFadingOut={isFadingOut} />
         ) : (
           <>
-            <PaginationButton
-              className="ml-auto"
-              page={page}
-              size={size}
-              totalCount={data?.totalCount}
-              onPageChange={setPage}
-            />
+            {data?.invitations.length ? (
+              <PaginationButton
+                className="ml-auto"
+                page={page}
+                size={size}
+                totalCount={data?.totalCount}
+                onPageChange={setPage}
+              />
+            ) : (
+              ''
+            )}
             <Button
               color="violet-white"
               className="col-start-2 row-start-2 h-[26px] gap-2 justify-self-end !rounded-[4px] px-3 text-[12px] md:col-start-3 md:row-start-1 md:h-[32px] md:px-4 md:!text-[14px]"
@@ -79,7 +83,7 @@ export default function DashboardInvitations({
                 height={16}
                 width={16}
               />
-              <span>초대하기</span>
+              <span className="h-36px">초대하기</span>
             </Button>
             <h2 className="col-start-1 row-start-2 text-base text-[var(--gray-D9D9D9)] md:text-[16px]">
               이메일

--- a/src/app/globals.css
+++ b/src/app/globals.css
@@ -290,7 +290,7 @@
 
   /*  아바타, 프로필 CSS */
   .profile-avatar {
-    @apply cursor-default border-2 border-solid border-white font-bold text-white;
+    @apply cursor-default font-bold text-white;
   }
 
   /* 칩 CSS */

--- a/src/components/common/Profile.tsx
+++ b/src/components/common/Profile.tsx
@@ -7,6 +7,7 @@ type AvatarProfileProps = {
   profileImg?: string | null;
   userName: string;
   size?: 'sm' | 'md' | 'lg';
+  isBorder?: boolean;
 } & HTMLAttributes<HTMLDivElement>;
 
 type UserProfileProps = AvatarProfileProps;
@@ -39,6 +40,7 @@ export function AvatarProfile({
   profileImg = null,
   userName,
   size,
+  isBorder = true,
 }: AvatarProfileProps) {
   const { container, textSize } = size
     ? ChipSizeMap[size]
@@ -47,8 +49,13 @@ export function AvatarProfile({
         textSize: 'text-12px md:text-base',
       };
   const { bgClass } = getTextBasedColorClasses(userName, 'profile');
+
+  const borderStyle = isBorder ? 'border-2 border-solid border-white' : '';
+
   return (
-    <Avatar className={`${container} profile-avatar cursor-pointer`}>
+    <Avatar
+      className={`${container} ${borderStyle} profile-avatar cursor-pointer`}
+    >
       <AvatarImage src={profileImg ?? undefined} />
       <AvatarFallback className={`${bgClass} ${textSize}`}>
         {userName.toUpperCase().slice(0, 1)}
@@ -72,10 +79,16 @@ export function UserProfile({
   profileImg = null,
   userName = '',
   size,
+  isBorder = true,
 }: UserProfileProps) {
   return (
     <div className="flex cursor-pointer items-center gap-3 text-base">
-      <AvatarProfile profileImg={profileImg} userName={userName} size={size} />
+      <AvatarProfile
+        profileImg={profileImg}
+        userName={userName}
+        size={size}
+        isBorder={isBorder}
+      />
       {size !== 'md' && <span className="font-medium">{userName}</span>}
     </div>
   );

--- a/src/components/common/UploadImageButton_Mypage.tsx
+++ b/src/components/common/UploadImageButton_Mypage.tsx
@@ -89,10 +89,10 @@ const UploadImageButton = ({
       )}
       <input
         type="file"
-        accept="image/*"
         className="hidden"
         ref={fileInputRef}
         onChange={handleFileChange}
+        accept="image/jpeg, image/png, image/gif"
       />
     </div>
   );


### PR DESCRIPTION
### 🚨 PR 제목 컨벤션 (필수)

- `feat: 새로운 기능 추가`
- `fix: 버그 수정`
- `docs: 문서 변경`
- `chore: 기타 작업`
- `허용된 타입 목록: feat|fix|docs|style|refactor|perf|test|build|ci|chore|revert`
- Linear Issue Key 를 포함해주세요. 예: `LIN-123/feat: 새로운 기능 추가`

## 🪓 관련 Linear Issue

Linear 이슈 링크: https://linear.app/fe16-intermediate-project/issue/LIN-78/마이페이지-이미지-업로드-svg-막음-초대목록-네비게이션-프로필-아바타-border-style

## 💡 변경 사항 요약
마이페이지 이미지 업로드 SVG 막음, 초대목록 네비게이션, 프로필 아바타 border style

### 📌 세부 변경 내용
**마이 페이지 이미지, JPG, PNG, GIF만 받게 설정** 
`accept="image/jpeg, image/png, image/gif"`

**초대목록, 초대 없을 때 내비게이션 숨김**

**프로필 아바타 isBorder 추가**
`true` : 기본값, border가 설정되어 있습니다.
`false` : border 삭제

### 🧪 테스트 방법 및 결과 (선택 사항)

### 📸 스크린샷 (선택 사항)

### ✍️ 추가 코멘트 (선택 사항)
