### PR TITLE
LIN-81/fix: 할 일 카드 수정

### DIFF
--- a/src/app/dialog-components/CardAuthor.tsx
+++ b/src/app/dialog-components/CardAuthor.tsx
@@ -7,9 +7,15 @@ import { AvatarProfile } from '../../components/common/Profile';
 interface CardAuthorProps extends HTMLAttributes<HTMLDivElement> {
   author?: string;
   dueDate?: string;
+  profileImg?: string;
 }
 
-const CardAuthor = ({ className, author, dueDate }: CardAuthorProps) => {
+const CardAuthor = ({
+  className,
+  author,
+  dueDate,
+  profileImg,
+}: CardAuthorProps) => {
   const baseStyles =
     'grid px-4 py-2 text-left grid-cols-2 grid-rows-[min-content_auto] gap-x-4 gap-y-2';
 
@@ -36,7 +42,11 @@ const CardAuthor = ({ className, author, dueDate }: CardAuthorProps) => {
       </span>
 
       <div className="col-start-1 col-end-2 row-start-2 row-end-3 flex items-center gap-2 md:col-start-1 md:col-end-2 md:row-start-2 md:row-end-3">
-        <AvatarProfile userName={author || ''} size="sm" />
+        <AvatarProfile
+          userName={author || ''}
+          size="sm"
+          profileImg={profileImg}
+        />
         <span className={cellFtStyles}>{author}</span>
       </div>
       <div

--- a/src/app/dialog-components/CardAuthor.tsx
+++ b/src/app/dialog-components/CardAuthor.tsx
@@ -35,12 +35,12 @@ const CardAuthor = ({
       >
         담당자
       </span>
+
       <span
         className={`${colHeaderFtStyles} col-start-2 col-end-3 row-start-1 row-end-2 md:col-start-1 md:col-end-2 md:row-start-3 md:row-end-4`}
       >
         마감일
       </span>
-
       <div className="col-start-1 col-end-2 row-start-2 row-end-3 flex items-center gap-2 md:col-start-1 md:col-end-2 md:row-start-2 md:row-end-3">
         <AvatarProfile
           userName={author || ''}
@@ -49,10 +49,15 @@ const CardAuthor = ({
         />
         <span className={cellFtStyles}>{author}</span>
       </div>
+
       <div
         className={`${cellFtStyles} col-start-2 col-end-3 row-start-2 row-end-3 flex self-center md:col-start-1 md:col-end-2 md:row-start-4 md:row-end-5`}
       >
-        {dueDate && formattedDate(dueDate)}
+        {dueDate ? (
+          formattedDate(dueDate)
+        ) : (
+          <span className="text-taskify-neutral-400">마감일 미정</span>
+        )}
       </div>
     </div>
   );

--- a/src/app/dialog-components/Comment.tsx
+++ b/src/app/dialog-components/Comment.tsx
@@ -54,7 +54,11 @@ const Comment = ({ className, comment, cardId }: CommentProps) => {
 
   return (
     <div className={className}>
-      <AvatarProfile userName={comment.author.nickname} size="sm" />
+      <AvatarProfile
+        userName={comment.author.nickname}
+        size="sm"
+        profileImg={comment.author.profileImageUrl}
+      />
       <div className="flex grow-1 flex-col gap-2">
         <div className="flex items-end gap-2">
           <span className="text-taskify-xs-semibold md:text-taskify-md-semibold text-taskify-neutral-700">

--- a/src/app/globals.css
+++ b/src/app/globals.css
@@ -521,8 +521,13 @@
   * {
     @apply border-border outline-ring/50;
   }
+
   body {
     @apply bg-background text-foreground;
+  }
+
+  body[data-scroll-locked] {
+    margin-right: 0px !important; /* Dialog 오픈 시 margin 변경 오버라이딩 (라이브러리 값이 !impotant여서 똑같이 !impotant) */
   }
 }
 
@@ -633,15 +638,6 @@
   --sidebar-ring: oklch(0.556 0 0);
 }
 
-@layer base {
-  * {
-    @apply border-border outline-ring/50;
-  }
-  body {
-    @apply bg-background text-foreground;
-  }
-}
-
 @theme inline {
   --radius-sm: calc(var(--radius) - 4px);
   --radius-md: calc(var(--radius) - 2px);
@@ -747,15 +743,6 @@
   --sidebar-accent-foreground: oklch(0.985 0 0);
   --sidebar-border: oklch(1 0 0 / 10%);
   --sidebar-ring: oklch(0.556 0 0);
-}
-
-@layer base {
-  * {
-    @apply border-border outline-ring/50;
-  }
-  body {
-    @apply bg-background text-foreground;
-  }
 }
 
 @layer utilities {

--- a/src/components/common/dialog/TaskCardDialog.tsx
+++ b/src/components/common/dialog/TaskCardDialog.tsx
@@ -33,7 +33,7 @@ const TaskCardDialog = ({
   columnName,
 }: TaskCardDialogProps) => {
   const { data, isPending } = useQuery({
-    queryKey: ['detailCard', cardId],
+    queryKey: ['cards', cardId],
     queryFn: () => getCard(cardId),
   });
 
@@ -82,6 +82,7 @@ const TaskCardDialog = ({
           className="border-taskify-neutral-300 col-start-1 col-end-5 rounded-lg border-1 md:col-start-5 md:col-end-6 md:row-span-3 md:mt-15 md:h-[155px] md:w-[181px]"
           author={data?.assignee.nickname}
           dueDate={data?.dueDate}
+          profileImg={data?.assignee.profileImageUrl}
         />
       )}
 

--- a/src/components/common/dialog/TaskCardDialog.tsx
+++ b/src/components/common/dialog/TaskCardDialog.tsx
@@ -41,7 +41,7 @@ const TaskCardDialog = ({
 
   return (
     <DialogContent
-      className="md:grid-cols-[repeat(4, 1fr)_181px] dialog-scrollable-content grid h-[50vh] max-h-[710px] max-w-[327px] grid-cols-4 gap-4 overflow-auto px-4 md:max-h-[766px] md:max-w-[678px] md:gap-6 md:px-8 lg:max-w-[732px]"
+      className="md:grid-cols-[repeat(4, 1fr)_181px] dialog-scrollable-content grid h-[50vh] max-h-[710px] max-w-[327px] grid-cols-4 grid-rows-[min-content_min-content_min-content_1fr_min-content] gap-4 overflow-auto px-4 md:max-h-[766px] md:max-w-[678px] md:gap-6 md:px-8 lg:max-w-[732px] lg:grid-rows-[min-content_auto_1fr_min-content]"
       showCloseButton={false}
     >
       {/** Header 영역 */}


### PR DESCRIPTION
### 🚨 PR 제목 컨벤션 (필수)

- `feat: 새로운 기능 추가`
- `fix: 버그 수정`
- `docs: 문서 변경`
- `chore: 기타 작업`
- `허용된 타입 목록: feat|fix|docs|style|refactor|perf|test|build|ci|chore|revert`
- Linear Issue Key 를 포함해주세요. 예: `LIN-123/feat: 새로운 기능 추가`

## 🪓 관련 Linear Issue

Linear 이슈 링크: [LIN-81: 할 일 카드 다이얼로그 수정](https://linear.app/fe16-intermediate-project/issue/LIN-81/할-일-카드-다이얼로그-수정)

## 💡 변경 사항 요약

할 일 카드 수정

### 📌 세부 변경 내용

- 담당자, 댓글에서 프로필 이미지 안 보이던 현상 수정
- 할 일 카드 수정 후 상세 다이얼로그에 갱신되지 않던 현상 수정
- 할 일 카드 내부 콘텐츠 요소가 다이얼로그 크기보다 작을 시 레이아웃 늘어지던 현상 수정
- 다이얼로그 오픈 시, `body`에 의도치 않던 `margin-right`값이 추가되던 현상 수정
