### PR TITLE
LIN-95/style: 테마 체인저 버튼 스타일 적용

### DIFF
--- a/src/components/common/ThemeChanger.tsx
+++ b/src/components/common/ThemeChanger.tsx
@@ -1,17 +1,66 @@
 'use client';
 
+import clsx from 'clsx';
+import { MoonStar, Sun } from 'lucide-react';
 import { useTheme } from 'next-themes';
+import { useEffect, useState } from 'react';
 
 const ThemeChanger = () => {
-  const { theme, setTheme } = useTheme();
+  const { resolvedTheme, setTheme } = useTheme();
+  const [mounted, setMounted] = useState(false);
+
+  // React 서버 컴포넌트 환경에서 hydration 오류를 방지하기 위해 이 패턴을 권장
+  // 서버와 클라이언트에서 렌더링 결과가 달라지는 것을 방지
+  useEffect(() => {
+    setMounted(true);
+  }, []);
+
+  if (!mounted) {
+    return null;
+  }
+
+  const buttonClasses = clsx(
+    'group fixed right-6 bottom-6 z-10 flex h-14 w-14 cursor-pointer items-center justify-center rounded-full border-3 shadow-lg transition-all duration-200 hover:opacity-100 md:h-16 md:w-16 overflow-hidden',
+    {
+      'border-orange-400 bg-gradient-to-br from-yellow-200 to-yellow-400 opacity-50':
+        resolvedTheme === 'light',
+      'dark:border-blue-50 dark:bg-gradient-to-br dark:from-blue-400 dark:to-blue-600':
+        resolvedTheme === 'dark',
+    },
+  );
 
   return (
     <button
       type="button"
-      className="align-center fixed right-10 bottom-10 flex h-20 w-20 items-center justify-center rounded-full border bg-amber-500"
-      onClick={() => setTheme(theme === 'dark' ? 'light' : 'dark')}
+      className={buttonClasses}
+      aria-label="테마 체인지 버튼"
+      onClick={() => setTheme(resolvedTheme === 'dark' ? 'light' : 'dark')}
     >
-      테마체인저
+      {/* ☀️ 해 아이콘 - Light 모드일 때만 아래에서 위로 나타남 */}
+      <div
+        className={clsx(
+          'absolute inset-0 flex items-center justify-center transition-transform duration-300',
+          {
+            'translate-y-0': resolvedTheme === 'light',
+            'translate-y-full': resolvedTheme !== 'light',
+          },
+        )}
+      >
+        <Sun className="h-9 w-9 fill-orange-400 stroke-orange-400 shadow-inner transition-transform duration-200 group-hover:scale-110 md:h-10 md:w-10" />
+      </div>
+
+      {/* 🌙 달 아이콘 - Dark 모드일 때만 아래에서 위로 나타남 */}
+      <div
+        className={clsx(
+          'absolute inset-0 flex items-center justify-center transition-transform duration-300',
+          {
+            'translate-y-0': resolvedTheme === 'dark',
+            'translate-y-full': resolvedTheme !== 'dark',
+          },
+        )}
+      >
+        <MoonStar className="h-7 w-7 fill-blue-100 stroke-blue-100 shadow-inner transition-transform duration-200 group-hover:scale-115 md:h-8 md:w-8" />
+      </div>
     </button>
   );
 };

--- a/src/components/common/ThemeChanger.tsx
+++ b/src/components/common/ThemeChanger.tsx
@@ -20,9 +20,9 @@ const ThemeChanger = () => {
   }
 
   const buttonClasses = clsx(
-    'group fixed right-6 bottom-6 z-10 flex h-14 w-14 cursor-pointer items-center justify-center rounded-full border-3 shadow-lg transition-all duration-200 hover:opacity-100 md:h-16 md:w-16 overflow-hidden',
+    'group fixed right-6 bottom-6 z-10 flex h-14 w-14 cursor-pointer items-center justify-center rounded-full border-3 shadow-lg transition-all duration-200 opacity-50 hover:opacity-100 md:h-16 md:w-16 overflow-hidden',
     {
-      'border-orange-400 bg-gradient-to-br from-yellow-200 to-yellow-400 opacity-50':
+      'border-orange-400 bg-gradient-to-br from-yellow-200 to-yellow-400':
         resolvedTheme === 'light',
       'dark:border-blue-50 dark:bg-gradient-to-br dark:from-blue-400 dark:to-blue-600':
         resolvedTheme === 'dark',


### PR DESCRIPTION
### 🚨 PR 제목 컨벤션 (필수)

- `feat: 새로운 기능 추가`
- `fix: 버그 수정`
- `docs: 문서 변경`
- `chore: 기타 작업`
- `허용된 타입 목록: feat|fix|docs|style|refactor|perf|test|build|ci|chore|revert`
- Linear Issue Key 를 포함해주세요. 예: `LIN-123/feat: 새로운 기능 추가`

## 🪓 관련 Linear Issue

Linear 이슈 링크: [LIN-95: 다크모드 시스템 구축 및 적용](https://linear.app/fe16-intermediate-project/issue/LIN-95/다크모드-시스템-구축-및-적용)

## 💡 변경 사항 요약

테마 체인저 버튼 디자인 추가

### 📌 세부 변경 내용

- 테마 모드에 따라 해와 달 아이콘 추가
- 해와 달이 떠오르고 지는 애니메이션 추가
- 반응형 UI 추가

### 🧪 테스트 방법 및 결과 (선택 사항)

1. 테스트 페이지에서 작성
