### PR TITLE
LIN-98/feat: 마이페이지 이미지 없을 때, 대시보드 삭제, 대시보드 상세 일부분 배경 다크모드 적용

### DIFF
--- a/src/app/(protected)/dashboard/[dashboardId]/components/ColumnComponent.tsx
+++ b/src/app/(protected)/dashboard/[dashboardId]/components/ColumnComponent.tsx
@@ -117,7 +117,7 @@ const ColumnComponent = ({
   return (
     <section className="shrink-0 border-r-1 px-5 lg:max-w-[354px]">
       <div className="border-taskify-neutral-300 dark:bg-taskify-dark-bg bg-taskify-neutral-100 flex h-full shrink-0 flex-col border-t-1 pt-[20px]">
-        <div className="bg-taskify-neutral-100 sticky top-30 z-2 items-end pt-1 md:top-15 lg:static">
+        <div className="bg-taskify-neutral-100 dark:bg-taskify-dark-bg sticky top-30 z-2 items-end pt-1 md:top-15 lg:static">
           <div className="flex shrink-0 items-end justify-between">
             <div className="flex items-center">
               <p className="bg-taskify-violet-primary h-2 w-2 shrink-0 rounded-full" />

--- a/src/app/(protected)/dashboard/[dashboardId]/edit/page.tsx
+++ b/src/app/(protected)/dashboard/[dashboardId]/edit/page.tsx
@@ -80,7 +80,7 @@ export default function DashboardEditPage() {
         {/*  대시보드 삭제하기 */}
         <Button
           color="white-black"
-          className="btn-removeDash border-taskify-neutral-300 w-full border bg-transparent md:max-w-[700px]"
+          className="btn-removeDash border-taskify-neutral-300 dark:bg-taskify-black-400 dark:text-taskify-gray-400 dark:hover:bg-taskify-black-500 w-full border bg-transparent md:max-w-[700px] dark:border-none"
           onClick={() => {
             openDialog({
               dialogComponent: (

--- a/src/components/common/UploadImageButton_Mypage.tsx
+++ b/src/components/common/UploadImageButton_Mypage.tsx
@@ -83,7 +83,7 @@ const UploadImageButton = ({
           </div>
         </>
       ) : (
-        <div className="flex h-full w-full flex-col items-center justify-center bg-gray-50 text-sm text-gray-500">
+        <div className="dark:bg-taskify-black-300 flex h-full w-full flex-col items-center justify-center bg-gray-50 text-sm text-gray-500">
           <FaPlus className="text-taskify-violet-primary mb-1 h-6 w-6" />
         </div>
       )}


### PR DESCRIPTION
### 🚨 PR 제목 컨벤션 (필수)

- `feat: 새로운 기능 추가`
- `fix: 버그 수정`
- `docs: 문서 변경`
- `chore: 기타 작업`
- `허용된 타입 목록: feat|fix|docs|style|refactor|perf|test|build|ci|chore|revert`
- Linear Issue Key 를 포함해주세요. 예: `LIN-123/feat: 새로운 기능 추가`

## 🪓 관련 Linear Issue

Linear 이슈 링크: https://linear.app/fe16-intermediate-project/issue/LIN-98/마이페이지-프로필-이미지-없을-때-다크모드

## 💡 변경 사항 요약

### 📌 세부 변경 내용
마이페이지 이미지 없을 때, 대시보드 삭제, 대시보드 상세 일부분 배경 다크모드 적용

### 🧪 테스트 방법 및 결과 (선택 사항)

1.
2.

### 📸 스크린샷 (선택 사항)

### ✍️ 추가 코멘트 (선택 사항)

-
