### PR TITLE
LIN-103/fix: 할 일 카드 삭제 시 대시보드 카드 리스트에 갱신 안됨 수정

### DIFF
--- a/src/components/common/dialog/ConfirmTaskCardDeletionDialog.tsx
+++ b/src/components/common/dialog/ConfirmTaskCardDeletionDialog.tsx
@@ -1,4 +1,4 @@
-import { useMutation } from '@tanstack/react-query';
+import { useMutation, useQueryClient } from '@tanstack/react-query';
 import { FormEvent } from 'react';
 
 import { Button } from '@/components/ui/Button';
@@ -22,11 +22,15 @@ const ConfirmTaskCardDeletionDialog = ({
   cardId,
 }: ConfirmColumnDeletionDialogProps) => {
   const { openDialog, closeDialog, goBack } = useDialogStore();
+  const queryClient = useQueryClient();
 
   const { mutate, isPending } = useMutation({
     mutationFn: deleteCard,
     onSuccess: () => {
       closeDialog();
+      queryClient.invalidateQueries({
+        queryKey: ['cards'],
+      });
     },
     onError: (_error) => {
       openDialog({


### PR DESCRIPTION
### 🚨 PR 제목 컨벤션 (필수)

- `feat: 새로운 기능 추가`
- `fix: 버그 수정`
- `docs: 문서 변경`
- `chore: 기타 작업`
- `허용된 타입 목록: feat|fix|docs|style|refactor|perf|test|build|ci|chore|revert`
- Linear Issue Key 를 포함해주세요. 예: `LIN-123/feat: 새로운 기능 추가`

## 🪓 관련 Linear Issue

Linear 이슈 링크: [LIN-103: 할 일 카드 삭제 후 dashboard에 갱신 안됨 수정](https://linear.app/fe16-intermediate-project/issue/LIN-103/할-일-카드-삭제-후-dashboard에-갱신-안됨-수정)

## 💡 변경 사항 요약

할 일 카드 삭제 시 대시보드 카드 리스트에 갱신 안됨 수정
