### PR TITLE
LIN-105/fix: 대시보드 관리 페이지에서 대시보드 삭제 후 리다이렉트 수정

### DIFF
--- a/src/components/common/dialog/ConfirmDashboardDeletionDialog.tsx
+++ b/src/components/common/dialog/ConfirmDashboardDeletionDialog.tsx
@@ -30,8 +30,10 @@ const ConfirmDashboardDeletionDialog = ({
   const deleteMutation = useDeleteDashboard({
     onSuccess: () => {
       queryClient.invalidateQueries({ queryKey: ['dashboards'] });
-      router.push('/mydashboard');
       closeDialog();
+      setTimeout(() => {
+        router.push('/mydashboard');
+      }, 100);
     },
   });
 


### PR DESCRIPTION
### 🚨 PR 제목 컨벤션 (필수)

- `feat: 새로운 기능 추가`
- `fix: 버그 수정`
- `docs: 문서 변경`
- `chore: 기타 작업`
- `허용된 타입 목록: feat|fix|docs|style|refactor|perf|test|build|ci|chore|revert`
- Linear Issue Key 를 포함해주세요. 예: `LIN-123/feat: 새로운 기능 추가`

## 🪓 관련 Linear Issue

Linear 이슈 링크: [LIN-105: 대시보드 삭제 이후 리다이렉팅이 되지 않는 문제 수정](https://linear.app/fe16-intermediate-project/issue/LIN-105/대시보드-삭제-이후-리다이렉팅이-되지-않는-문제-수정)

## 💡 변경 사항 요약

대시보드 관리 페이지에서 대시보드 삭제 후 리다이렉트 수정

### 📌 세부 변경 내용

- `invalidateQuery`와 `router.push` 사이의 타이밍을 주어서 해결

### ✍️ 추가 코멘트 (선택 사항)

- 대시보드 접근 권한이 없을 때 리다이렉트 추가해야함
